### PR TITLE
O2HTML 2x performance enhancements

### DIFF
--- a/src/External/O2Html.Tests/Dom/ElementTests.cs
+++ b/src/External/O2Html.Tests/Dom/ElementTests.cs
@@ -5,215 +5,215 @@ using System.Linq;
 namespace O2Html.Tests.Dom;
 
 public class ElementTests
+{
+    [Fact]
+    public void TagName_Is_Cleaned_From_Xml_Node_Separators()
     {
-        [Fact]
-        public void TagName_Is_Cleaned_From_Xml_Node_Separators()
-        {
-            var element = new Element("<div/>");
-            Assert.Equal("div", element.TagName);
-        }
-
-        [Fact]
-        public void TagName_Casing_Does_Not_Change()
-        {
-            var element = new Element("dIv");
-            Assert.Equal("dIv", element.TagName);
-        }
-
-        [Fact]
-        public void Considered_IsSelfClosing_If_TagName_Ends_With_Angle_Bracket()
-        {
-            var element = new Element("<div/>");
-            Assert.True(element.IsSelfClosing);
-        }
-
-        [Fact]
-        public void Not_Considered_IsSelfClosing_If_TagName_Does_Not_End_With_Angle_Bracket()
-        {
-            var element = new Element("<div");
-            Assert.False(element.IsSelfClosing);
-        }
-
-        [Fact]
-        public void Attributes_Are_Empty_On_Initialization()
-        {
-            Assert.Empty(new Element("div").Attributes);
-        }
-
-        [Fact]
-        public void Children_Are_Empty_On_Initialization()
-        {
-            Assert.Empty(new Element("div").Children);
-        }
-
-        [Fact]
-        public void ChildElements_Returns_Children_Of_Type_Element()
-        {
-            var element = new Element("div");
-            var childNode = new TextNode("Test");
-            element.AddChild(childNode);
-
-            var childElement = new Element("p");
-            element.AddChild(childElement);
-
-            Assert.Equal(childElement, element.ChildElements.Single());
-        }
-
-        [Fact]
-        public void AddChild_Adds_Node_To_Children()
-        {
-            var element = new Element("div");
-            var childNode = new TextNode("Test");
-            element.AddChild(childNode);
-
-            Assert.Equal(childNode, element.Children.Single());
-        }
-
-        [Fact]
-        public void RemoveChild_Removes_Node_From_Children()
-        {
-            var element = new Element("div");
-            var childNode = new TextNode("Test");
-            element.AddChild(childNode);
-            element.RemoveChild(childNode);
-
-            Assert.Empty(element.Children);
-        }
-
-        [Fact]
-        public void HasAttribute_Returns_If_Element_Has_Attribute()
-        {
-            var element = new Element("div");
-            element.Attributes.Add(new ElementAttribute(element, "test"));
-
-            Assert.True(element.HasAttribute("test"));
-        }
-
-        [Fact]
-        public void GetAttribute_Returns_Attribute_When_It_Exists()
-        {
-            var element = new Element("div");
-            var attribute = new ElementAttribute(element, "test");
-            element.Attributes.Add(attribute);
-
-            Assert.Equal(attribute, element.GetAttribute("test"));
-        }
-
-        [Fact]
-        public void GetAttribute_Returns_Null_When_Attribute_Does_Not_Exist()
-        {
-            var element = new Element("div");
-
-            Assert.Null(element.GetAttribute("test"));
-        }
-
-        [Fact]
-        public void GetOrAddAttribute_Returns_Attribute_When_It_Exists()
-        {
-            var element = new Element("div");
-            var attribute = new ElementAttribute(element, "test");
-            element.Attributes.Add(attribute);
-
-            Assert.Equal(attribute, element.GetOrAddAttribute("test"));
-        }
-
-        [Fact]
-        public void GetOrAddAttribute_Adds_And_Returns_Attribute_When_It_Does_Not_Exist()
-        {
-            var element = new Element("div");
-            var attribute = element.GetOrAddAttribute("test");
-
-            Assert.Equal(attribute, element.GetAttribute("test"));
-        }
-
-        [Fact]
-        public void GetOrAddAttribute_Does_Not_Add_Duplicates()
-        {
-            var element = new Element("div");
-            element.GetOrAddAttribute("test");
-            element.GetOrAddAttribute("test");
-
-            Assert.Single(element.Attributes.Where(a => a.Name == "test"));
-        }
-
-        [Fact]
-        public void SetOrAddAttribute_Returns_Attribute_And_Sets_Value_When_It_Exist()
-        {
-            var element = new Element("div");
-            var attribute = new ElementAttribute(element, "test");
-            element.Attributes.Add(attribute);
-
-            element.SetOrAddAttribute("test", "val");
-
-            Assert.Equal(attribute, element.GetAttribute("test"));
-            Assert.Equal("val", attribute.Value);
-        }
-
-        [Fact]
-        public void SetOrAddAttribute_Adds_And_Returns_Attribute_And_Sets_Value_When_It_Does_Not_Exist()
-        {
-            var element = new Element("div");
-            var attribute = element.SetOrAddAttribute("test", "val");
-
-            Assert.Equal(attribute, element.GetAttribute("test"));
-            Assert.Equal("val", attribute.Value);
-        }
-
-        [Fact]
-        public void SetOrAddAttribute_Does_Not_Add_Duplicates()
-        {
-            var element = new Element("div");
-            element.SetOrAddAttribute("test", "val");
-            element.SetOrAddAttribute("test", "val");
-
-            Assert.Single(element.Attributes.Where(a => a.Name == "test"));
-        }
-
-        [Fact]
-        public void DeleteAttribute_By_Name_Removes_Attribute()
-        {
-            var element = new Element("div");
-            var attribute = element.GetOrAddAttribute("test");
-
-            element.DeleteAttribute(attribute.Name);
-
-            Assert.Empty(element.Attributes.Where(a => a.Name == attribute.Name));
-        }
-
-        [Fact]
-        public void Attribute_Delete_Removes_Attribute()
-        {
-            var element = new Element("div");
-            var attribute = element.GetOrAddAttribute("test");
-
-            attribute.Delete();
-
-            Assert.DoesNotContain(attribute, element.Attributes);
-        }
-
-        [Fact]
-        public void HtmlTest_Empty_Not_SelfClosing()
-        {
-            var element = new Element("div");
-
-            Assert.Equal("<div></div>", element.ToHtml());
-        }
-
-        [Fact]
-        public void HtmlTest_Empty_SelfClosing()
-        {
-            var element = new Element("<br/>");
-
-            Assert.Equal("<br/>", element.ToHtml());
-        }
-
-        [Fact]
-        public void HtmlTest_With_Attributes()
-        {
-            var element = new Element("div");
-            element.SetOrAddAttribute("id", "test");
-            element.SetOrAddAttribute("style", "width: 100%");
-
-            Assert.Equal("<div id=\"test\" style=\"width: 100%\"></div>", element.ToHtml());
-        }
+        var element = new Element("<div/>");
+        Assert.Equal("div", element.TagName);
     }
+
+    [Fact]
+    public void TagName_Casing_Does_Not_Change()
+    {
+        var element = new Element("dIv");
+        Assert.Equal("dIv", element.TagName);
+    }
+
+    [Fact]
+    public void Considered_IsSelfClosing_If_TagName_Ends_With_Angle_Bracket()
+    {
+        var element = new Element("<div/>");
+        Assert.True(element.IsSelfClosing);
+    }
+
+    [Fact]
+    public void Not_Considered_IsSelfClosing_If_TagName_Does_Not_End_With_Angle_Bracket()
+    {
+        var element = new Element("<div");
+        Assert.False(element.IsSelfClosing);
+    }
+
+    [Fact]
+    public void Attributes_Are_Empty_On_Initialization()
+    {
+        Assert.Empty(new Element("div").Attributes);
+    }
+
+    [Fact]
+    public void Children_Are_Empty_On_Initialization()
+    {
+        Assert.Empty(new Element("div").Children);
+    }
+
+    [Fact]
+    public void ChildElements_Returns_Children_Of_Type_Element()
+    {
+        var element = new Element("div");
+        var childNode = new TextNode("Test");
+        element.AddChild(childNode);
+
+        var childElement = new Element("p");
+        element.AddChild(childElement);
+
+        Assert.Equal(childElement, element.ChildElements.Single());
+    }
+
+    [Fact]
+    public void AddChild_Adds_Node_To_Children()
+    {
+        var element = new Element("div");
+        var childNode = new TextNode("Test");
+        element.AddChild(childNode);
+
+        Assert.Equal(childNode, element.Children.Single());
+    }
+
+    [Fact]
+    public void RemoveChild_Removes_Node_From_Children()
+    {
+        var element = new Element("div");
+        var childNode = new TextNode("Test");
+        element.AddChild(childNode);
+        element.RemoveChild(childNode);
+
+        Assert.Empty(element.Children);
+    }
+
+    [Fact]
+    public void HasAttribute_Returns_If_Element_Has_Attribute()
+    {
+        var element = new Element("div");
+        element.Attributes.Add(new ElementAttribute(element, "test"));
+
+        Assert.True(element.HasAttribute("test"));
+    }
+
+    [Fact]
+    public void GetAttribute_Returns_Attribute_When_It_Exists()
+    {
+        var element = new Element("div");
+        var attribute = new ElementAttribute(element, "test");
+        element.Attributes.Add(attribute);
+
+        Assert.Equal(attribute, element.GetAttribute("test"));
+    }
+
+    [Fact]
+    public void GetAttribute_Returns_Null_When_Attribute_Does_Not_Exist()
+    {
+        var element = new Element("div");
+
+        Assert.Null(element.GetAttribute("test"));
+    }
+
+    [Fact]
+    public void GetOrAddAttribute_Returns_Attribute_When_It_Exists()
+    {
+        var element = new Element("div");
+        var attribute = new ElementAttribute(element, "test");
+        element.Attributes.Add(attribute);
+
+        Assert.Equal(attribute, element.GetOrAddAttribute("test"));
+    }
+
+    [Fact]
+    public void GetOrAddAttribute_Adds_And_Returns_Attribute_When_It_Does_Not_Exist()
+    {
+        var element = new Element("div");
+        var attribute = element.GetOrAddAttribute("test");
+
+        Assert.Equal(attribute, element.GetAttribute("test"));
+    }
+
+    [Fact]
+    public void GetOrAddAttribute_Does_Not_Add_Duplicates()
+    {
+        var element = new Element("div");
+        element.GetOrAddAttribute("test");
+        element.GetOrAddAttribute("test");
+
+        Assert.Single(element.Attributes.Where(a => a.Name == "test"));
+    }
+
+    [Fact]
+    public void SetOrAddAttribute_Returns_Attribute_And_Sets_Value_When_It_Exist()
+    {
+        var element = new Element("div");
+        var attribute = new ElementAttribute(element, "test");
+        element.Attributes.Add(attribute);
+
+        element.SetOrAddAttribute("test", "val");
+
+        Assert.Equal(attribute, element.GetAttribute("test"));
+        Assert.Equal("val", attribute.Value);
+    }
+
+    [Fact]
+    public void SetOrAddAttribute_Adds_And_Returns_Attribute_And_Sets_Value_When_It_Does_Not_Exist()
+    {
+        var element = new Element("div");
+        var attribute = element.SetOrAddAttribute("test", "val");
+
+        Assert.Equal(attribute, element.GetAttribute("test"));
+        Assert.Equal("val", attribute.Value);
+    }
+
+    [Fact]
+    public void SetOrAddAttribute_Does_Not_Add_Duplicates()
+    {
+        var element = new Element("div");
+        element.SetOrAddAttribute("test", "val");
+        element.SetOrAddAttribute("test", "val");
+
+        Assert.Single(element.Attributes.Where(a => a.Name == "test"));
+    }
+
+    [Fact]
+    public void DeleteAttribute_By_Name_Removes_Attribute()
+    {
+        var element = new Element("div");
+        var attribute = element.GetOrAddAttribute("test");
+
+        element.DeleteAttribute(attribute.Name);
+
+        Assert.Empty(element.Attributes.Where(a => a.Name == attribute.Name));
+    }
+
+    [Fact]
+    public void Attribute_Delete_Removes_Attribute()
+    {
+        var element = new Element("div");
+        var attribute = element.GetOrAddAttribute("test");
+
+        attribute.Delete();
+
+        Assert.DoesNotContain(attribute, element.Attributes);
+    }
+
+    [Fact]
+    public void HtmlTest_Empty_Not_SelfClosing()
+    {
+        var element = new Element("div");
+
+        Assert.Equal("<div></div>", element.ToHtml());
+    }
+
+    [Fact]
+    public void HtmlTest_Empty_SelfClosing()
+    {
+        var element = new Element("<br/>");
+
+        Assert.Equal("<br/>", element.ToHtml());
+    }
+
+    [Fact]
+    public void HtmlTest_With_Attributes()
+    {
+        var element = new Element("div");
+        element.SetOrAddAttribute("id", "test");
+        element.SetOrAddAttribute("style", "width: 100%");
+
+        Assert.Equal("<div id=\"test\" style=\"width: 100%\"></div>", element.ToHtml());
+    }
+}

--- a/src/External/O2Html.Tests/Performance/PerformanceTests.cs
+++ b/src/External/O2Html.Tests/Performance/PerformanceTests.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using O2Html.Dom;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace O2Html.Tests.Performance;
+
+public class PerformanceTests
+{
+    private readonly ITestOutputHelper _testOutputHelper;
+    private static readonly Random _random = new Random();
+
+    public PerformanceTests(ITestOutputHelper testOutputHelper)
+    {
+        _testOutputHelper = testOutputHelper;
+    }
+
+    [Fact(Skip = "Adhoc for performance testing")]
+    public void LibComparison_Performance_Test()
+    {
+        var cars = GetCars(1000);
+
+        Benchmark("STJ", () => System.Text.Json.JsonSerializer.Serialize(cars));
+        Benchmark("Json.NET", () => Newtonsoft.Json.JsonConvert.SerializeObject(cars));
+        Benchmark("O2HTML", () => HtmlConvert.Serialize(cars).ToHtml());
+    }
+
+    [Fact(Skip = "Adhoc for performance testing")]
+    public void O2HTML_Performance_Tests()
+    {
+        var cars = GetCars(1000);
+
+        Element element = null!;
+
+        Benchmark("All", () =>
+        {
+            Benchmark("Serialize to Element", () => element = HtmlConvert.Serialize(cars));
+            Benchmark("To HTML", () => element.ToHtml());
+        });
+    }
+
+    [Fact(Skip = "Adhoc for performance testing")]
+    public void Profiling_Serialize()
+    {
+        var cars = GetCars(1000);
+        HtmlConvert.Serialize(cars);
+    }
+
+    private void Benchmark(string label, Action action, int runTimes = 1)
+    {
+        var timings = new List<double>();
+
+        for (int i = 0; i < runTimes; i++)
+        {
+            var start = DateTime.Now;
+            action();
+            timings.Add((DateTime.Now - start).TotalMilliseconds);
+        }
+
+        timings.Sort();
+        var median = timings[timings.Count / 2];
+
+        _testOutputHelper.WriteLine($"### {label.PadRight(25)} => MEDIAN: {median} | AVG: {timings.Average()}");
+    }
+
+    private static List<Car> GetCars(int count)
+    {
+        var cars = new List<Car>();
+
+        for (int i = 0; i < count; i++)
+            cars.Add(new Car());
+
+        return cars;
+    }
+
+    private static string GenerateRandomString(int length)
+    {
+        const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+        return new string(Enumerable.Repeat(chars, length)
+            .Select(s => s[_random.Next(s.Length)]).ToArray());
+    }
+
+    class Car
+    {
+        public Car()
+        {
+            Make = GenerateRandomString(10);
+            Model = GenerateRandomString(15);
+            Year = 2022;
+            CreatedDate = new DateTime(2022, 1, 1);
+            Features = new List<Feature>()
+            {
+                new Feature(),
+                new Feature(),
+                new Feature(),
+                new Feature(),
+                new Feature(),
+            };
+        }
+
+        public string Make { get; set; }
+        public string Model { get; set; }
+        public int Year { get; set; }
+        public DateTime CreatedDate { get; set; }
+        public List<Feature> Features { get; set; }
+    }
+
+    class Feature
+    {
+        public Feature()
+        {
+            Label = GenerateRandomString(15);
+            Description = GenerateRandomString(50);
+            Included = true;
+        }
+
+        public string Label { get; set; }
+        public string Description { get; set; }
+        public bool Included { get; set; }
+    }
+}

--- a/src/External/O2Html/Converters/DotNetTypeWithStringRepresentationHtmlConverter.cs
+++ b/src/External/O2Html/Converters/DotNetTypeWithStringRepresentationHtmlConverter.cs
@@ -6,28 +6,27 @@ namespace O2Html.Converters;
 
 public class DotNetTypeWithStringRepresentationHtmlConverter : HtmlConverter
 {
-    public override Element WriteHtml<T>(T obj, SerializationScope serializationScope, HtmlSerializer htmlSerializer)
+    public override Element WriteHtml<T>(T obj, Type type, SerializationScope serializationScope, HtmlSerializer htmlSerializer)
     {
         if (obj == null)
             return new Null().WithAddClass(htmlSerializer.SerializerSettings.CssClasses.Null);
 
         var str = obj.ToString()?
-            .Replace(" ", "&nbsp;")
-            .Replace("<", "&lt;")
-            .Replace(">", "&gt;")
-            .Replace("\n", "<br/>")
-        ;
+            .ReplaceIfExists(" ", "&nbsp;")
+            .ReplaceIfExists("<", "&lt;")
+            .ReplaceIfExists(">", "&gt;")
+            .ReplaceIfExists("\n", "<br/>");
 
-        return new Element("span").WithText(str ?? string.Empty);
+        return new Element("span").WithText(str);
     }
 
-    public override void WriteHtmlWithinTableRow<T>(Element tr, T obj, SerializationScope serializationScope, HtmlSerializer htmlSerializer)
+    public override void WriteHtmlWithinTableRow<T>(Element tr, T obj, Type type, SerializationScope serializationScope, HtmlSerializer htmlSerializer)
     {
-        tr.AddAndGetElement("td").AddChild(WriteHtml(obj, serializationScope, htmlSerializer));
+        tr.AddAndGetElement("td").AddChild(WriteHtml(obj, type, serializationScope, htmlSerializer));
     }
 
-    public override bool CanConvert(Type type)
+    public override bool CanConvert(HtmlSerializer htmlSerializer, Type type)
     {
-        return type.IsDotNetTypeWithStringRepresentation();
+        return htmlSerializer.GetTypeCategory(type) == TypeCategory.DotNetTypeWithStringRepresentation;
     }
 }

--- a/src/External/O2Html/Dom/ElementAttribute.cs
+++ b/src/External/O2Html/Dom/ElementAttribute.cs
@@ -33,9 +33,9 @@ public class ElementAttribute
         if (!string.IsNullOrWhiteSpace(value))
         {
             var values = Values.ToList();
-            if (appendIfExists || !values.Contains(value!))
+            if (appendIfExists || !values.Contains(value))
             {
-                values.Add(value!);
+                values.Add(value);
                 Set(string.Join(" ", values));
             }
         }

--- a/src/External/O2Html/Dom/Elements/CyclicReference.cs
+++ b/src/External/O2Html/Dom/Elements/CyclicReference.cs
@@ -1,12 +1,11 @@
+using System;
+
 namespace O2Html.Dom.Elements;
 
 public class CyclicReference : Element
 {
-    public CyclicReference(object? obj = null) : base("div")
+    public CyclicReference(Type type) : base("div")
     {
-        if (obj != null)
-        {
-            AddText($"Cyclic reference ({obj.GetType().GetReadableName(withNamespace: true, forHtml: true)})");
-        }
+        AddText($"Cyclic reference ({type.GetReadableName(withNamespace: true, forHtml: true)})");
     }
 }

--- a/src/External/O2Html/Dom/Node.cs
+++ b/src/External/O2Html/Dom/Node.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace O2Html.Dom;
 
 public abstract class Node
@@ -11,6 +13,7 @@ public abstract class Node
     public Element? Parent { get; internal set; }
 
     public abstract string ToHtml(Formatting? formatting = null);
+    public abstract void ToHtml(List<byte> output, Formatting? formatting = null);
 
     public void Delete()
     {

--- a/src/External/O2Html/Dom/TextNode.cs
+++ b/src/External/O2Html/Dom/TextNode.cs
@@ -1,22 +1,33 @@
+using System.Collections.Generic;
+using System.Text;
+
 namespace O2Html.Dom;
 
 public class TextNode : Node
 {
-    public TextNode(string text) : base(NodeType.Text)
+    public TextNode(string? text) : base(NodeType.Text)
     {
         Text = text;
     }
 
-    public string Text { get; private set; }
+    public string? Text { get; private set; }
 
-    public void SetText(string text)
+    public void SetText(string? text)
     {
         Text = text;
     }
 
     public override string ToHtml(Formatting? formatting = null)
     {
-        return Text ?? string.Empty;
+        var output = new List<byte>();
+        ToHtml(output, formatting);
+        return Encoding.UTF8.GetString(output.ToArray());
+    }
+
+    public override void ToHtml(List<byte> output, Formatting? formatting = null)
+    {
+        if (!string.IsNullOrEmpty(Text))
+            output.AddRange(Encoding.UTF8.GetBytes(Text));
     }
 
     public override string ToString() => ToHtml();

--- a/src/External/O2Html/HtmlConvert.cs
+++ b/src/External/O2Html/HtmlConvert.cs
@@ -7,6 +7,7 @@ public static class HtmlConvert
     public static Element Serialize<T>(T? obj, HtmlSerializerSettings? htmlSerializerSettings = null)
     {
         var serializer = HtmlSerializer.Create(htmlSerializerSettings);
-        return serializer.Serialize(obj);
+        var type = obj?.GetType() ?? typeof(T);
+        return serializer.Serialize(obj, type);
     }
 }

--- a/src/External/O2Html/HtmlConverter.cs
+++ b/src/External/O2Html/HtmlConverter.cs
@@ -5,9 +5,9 @@ namespace O2Html;
 
 public abstract class HtmlConverter
 {
-    public abstract Element WriteHtml<T>(T obj, SerializationScope serializationScope, HtmlSerializer htmlSerializer);
+    public abstract Element WriteHtml<T>(T obj, Type type, SerializationScope serializationScope, HtmlSerializer htmlSerializer);
 
-    public abstract void WriteHtmlWithinTableRow<T>(Element tr, T obj, SerializationScope serializationScope, HtmlSerializer htmlSerializer);
+    public abstract void WriteHtmlWithinTableRow<T>(Element tr, T obj, Type type, SerializationScope serializationScope, HtmlSerializer htmlSerializer);
 
-    public abstract bool CanConvert(Type type);
+    public abstract bool CanConvert(HtmlSerializer htmlSerializer, Type type);
 }

--- a/src/External/O2Html/HtmlElementExtensions.cs
+++ b/src/External/O2Html/HtmlElementExtensions.cs
@@ -43,13 +43,13 @@ public static class HtmlElementExtensions
         return child;
     }
 
-    public static TElement WithText<TElement>(this TElement element, string text) where TElement : Element
+    public static TElement WithText<TElement>(this TElement element, string? text) where TElement : Element
     {
         element.AddText(text);
         return element;
     }
 
-    public static TextNode AddAndGetText(this Element element, string text)
+    public static TextNode AddAndGetText(this Element element, string? text)
     {
         var child = new TextNode(text);
         element.AddChild(child);

--- a/src/External/O2Html/HtmlSerializer.cs
+++ b/src/External/O2Html/HtmlSerializer.cs
@@ -1,88 +1,165 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using O2Html.Dom;
+using System.Reflection;
 using O2Html.Converters;
+using O2Html.Dom;
 
 namespace O2Html;
 
-public class HtmlSerializer
+public sealed class HtmlSerializer
 {
+    private readonly Dictionary<Type, HtmlConverter?> _typeConverterCache = new();
+    private readonly Dictionary<Type, TypeCategory> _typeCategoryCache = new();
+    private readonly Dictionary<Type, PropertyInfo[]> _typePropertyCache = new();
+    private readonly Dictionary<Type, Type?> _collectionElementTypeCache = new();
+
     public HtmlSerializer(HtmlSerializerSettings? serializerSettings = null)
     {
         SerializerSettings = serializerSettings ?? new HtmlSerializerSettings();
         Converters = new List<HtmlConverter>();
+
+        if (SerializerSettings.Converters?.Any() == true)
+        {
+            // Insert settings converters at the beginning so they take precedence
+            foreach (var converter in SerializerSettings.Converters)
+            {
+                Converters.Add(converter);
+            }
+        }
 
         // Add default converters in this order, first converter in list
         // that can convert object takes precedence
         Converters.Add(new DotNetTypeWithStringRepresentationHtmlConverter());
         Converters.Add(new CollectionHtmlConverter());
         Converters.Add(new ObjectHtmlConverter());
-
-        if (SerializerSettings.Converters?.Any() == true)
-        {
-            // Insert settings converters at the beginning so they take precedence
-            // if user wants to remove one of the default converters they will have to do it manually
-            for (int i = 0; i < SerializerSettings.Converters.Count; i++)
-            {
-                Converters.Insert(i, SerializerSettings.Converters[i]);
-            }
-        }
     }
 
     public HtmlSerializerSettings SerializerSettings { get; }
 
     public List<HtmlConverter> Converters { get; }
 
-    public Element Serialize<T>(T? obj, SerializationScope? serializationScope = null)
+    public Element Serialize<T>(T? obj, Type type, SerializationScope? serializationScope = null)
     {
-        var type = obj?.GetType() ?? typeof(T);
         var converter = GetConverter(type);
         if (converter == null)
-            throw new HtmlSerializationException($"Could not find a convert for object of type: {type}");
+            throw new HtmlSerializationException($"Could not find a {nameof(HtmlConverter)} for type: {type}");
 
-        serializationScope = GetSerializationScope<T>(obj, serializationScope);
+        serializationScope = GetSerializationScope(type, obj, serializationScope);
 
-        return converter.WriteHtml(obj, serializationScope, this);
+        return converter.WriteHtml(obj, type, serializationScope, this);
     }
 
-    public void SerializeWithinTableRow<T>(Element tr, T? obj, SerializationScope? serializationScope = null)
+    public void SerializeWithinTableRow<T>(Element tr, T? obj, Type type, SerializationScope? serializationScope = null)
     {
-        var type = obj?.GetType() ?? typeof(T);
         var converter = GetConverter(type);
         if (converter == null)
-            throw new HtmlSerializationException($"Could not find an {nameof(HtmlConverter)} for object of type: {type}");
+            throw new HtmlSerializationException($"Could not find a {nameof(HtmlConverter)} for type: {type}");
 
-        serializationScope = GetSerializationScope<T>(obj, serializationScope);
+        serializationScope = GetSerializationScope(type, obj, serializationScope);
 
-        converter.WriteHtmlWithinTableRow(tr, obj, serializationScope, this);
+        converter.WriteHtmlWithinTableRow(tr, obj, type, serializationScope, this);
+    }
+
+    public TypeCategory GetTypeCategory(Type type)
+    {
+        if (_typeCategoryCache.TryGetValue(type, out var category))
+            return category;
+
+        if (IsDotNetTypeWithStringRepresentation(type))
+            category = TypeCategory.DotNetTypeWithStringRepresentation;
+        else if (IsCollectionType(type))
+            category = TypeCategory.Collection;
+        else
+            category = TypeCategory.SingleObject;
+
+        _typeCategoryCache.Add(type, category);
+        return category;
+    }
+
+    public PropertyInfo[] GetReadableProperties(Type type)
+    {
+        if (_typePropertyCache.TryGetValue(type, out var propertyInfos))
+            return propertyInfos;
+
+        propertyInfos = type.GetProperties(BindingFlags.Public | BindingFlags.Instance).Where(p => p.CanRead)
+            .OrderBy(p => p.Name)
+            .ToArray();
+
+        _typePropertyCache.Add(type, propertyInfos);
+        return propertyInfos;
+    }
+
+    public Type? GetElementType(Type collectionType)
+    {
+        if (_collectionElementTypeCache.TryGetValue(collectionType, out var elementType))
+            return elementType;
+
+        elementType = collectionType.GetCollectionElementType();
+
+        _collectionElementTypeCache.Add(collectionType, elementType);
+
+        return elementType;
     }
 
     private HtmlConverter? GetConverter(Type type)
     {
+        if (_typeConverterCache.TryGetValue(type, out var converter))
+            return converter;
+
         for (int i = 0; i < Converters.Count; i++)
         {
-            var converter = Converters[i];
-            if (converter.CanConvert(type))
+            converter = Converters[i];
+            if (converter.CanConvert(this, type))
+            {
+                _typeConverterCache.Add(type, converter);
                 return converter;
+            }
         }
 
+        _typeConverterCache.Add(type, null);
         return null;
     }
 
-    private SerializationScope GetSerializationScope<T>(T? obj, SerializationScope? serializationScope)
+    private SerializationScope GetSerializationScope<T>(Type type, T? obj, SerializationScope? serializationScope)
     {
         if (serializationScope == null)
             serializationScope = new SerializationScope();
         else
         {
-            bool createNewScope = obj != null && obj.GetType().IsObjectType();
+            bool createNewScope = obj != null && GetTypeCategory(type) == TypeCategory.SingleObject;
 
             if (createNewScope)
                 serializationScope = new SerializationScope(serializationScope);
         }
 
         return serializationScope;
+    }
+
+    private static bool IsDotNetTypeWithStringRepresentation(Type type)
+    {
+        return type.IsPrimitive ||
+               type.IsEnum ||
+               typeof(Exception).IsAssignableFrom(type) ||
+               type.In(
+                   typeof(string),
+                   typeof(decimal),
+                   typeof(DateTime),
+                   typeof(TimeSpan),
+                   typeof(DateTimeOffset)
+               ) ||
+               typeof(Type).IsAssignableFrom(type);
+    }
+
+    private static bool IsObjectType(Type type)
+    {
+        return !IsDotNetTypeWithStringRepresentation(type) && !IsCollectionType(type);
+    }
+
+    private static bool IsCollectionType(Type type)
+    {
+        return type != typeof(string) && typeof(IEnumerable).IsAssignableFrom(type);
     }
 
     public static HtmlSerializer Create(HtmlSerializerSettings? serializerSettings = null)

--- a/src/External/O2Html/InternalExtensions.cs
+++ b/src/External/O2Html/InternalExtensions.cs
@@ -1,8 +1,6 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 
 namespace O2Html;
 
@@ -13,39 +11,12 @@ internal static class InternalExtensions
         return collection.Contains(item);
     }
 
-    public static bool IsDotNetTypeWithStringRepresentation(this Type type)
+    public static string ReplaceIfExists(this string source, string strToReplace, string replaceWith)
     {
-        return type.IsPrimitive ||
-               type.IsEnum ||
-               typeof(Exception).IsAssignableFrom(type) ||
-               type.In(
-                   typeof(string),
-                   typeof(decimal),
-                   typeof(DateTime),
-                   typeof(TimeSpan),
-                   typeof(DateTimeOffset)
-               );
-    }
+        if (source.Contains(strToReplace))
+            return source.Replace(strToReplace, replaceWith);
 
-
-    public static bool IsObjectType(this Type type)
-    {
-        return !type.IsDotNetTypeWithStringRepresentation() && !type.IsCollectionType();
-    }
-
-    public static bool IsCollectionType(this Type type)
-    {
-        return type != typeof(string) && typeof(IEnumerable).IsAssignableFrom(type);
-    }
-
-    public static IEnumerable<PropertyInfo> GetReadableProperties(this Type type)
-    {
-        return type.GetProperties(BindingFlags.Public | BindingFlags.Instance).Where(p => p.CanRead);
-    }
-
-    public static IEnumerable<PropertyInfo> GetReadableProperties(this object obj)
-    {
-        return obj.GetType().GetReadableProperties();
+        return source;
     }
 
     public static string GetReadableName(this Type type, bool withNamespace = false, bool forHtml = false)
@@ -73,8 +44,70 @@ internal static class InternalExtensions
         }
 
         if (forHtml)
-            name = name.Replace("<", "&lt;").Replace(">", "&gt;");
+        {
+            name = name
+                .ReplaceIfExists("<", "&lt;")
+                .ReplaceIfExists(">", "&gt;");
+        }
 
         return name;
+    }
+
+    internal static Type? GetCollectionElementType(this Type collectionType)
+    {
+        Type? elementType;
+
+        if (collectionType.IsArray)
+        {
+            elementType = collectionType.GetElementType();
+        }
+        else
+        {
+            Type? iEnumerable = FindIEnumerable(collectionType);
+
+            if (iEnumerable == null)
+            {
+                return typeof(object);
+            }
+
+            elementType = iEnumerable.GetGenericArguments()[0];
+        }
+
+        return elementType;
+    }
+
+    private static Type? FindIEnumerable(Type collectionType)
+    {
+        if (collectionType == typeof(string))
+        {
+            return null;
+        }
+
+        if (collectionType.IsGenericType)
+        {
+            foreach (Type arg in collectionType.GetGenericArguments())
+            {
+                Type iEnumerable = typeof(IEnumerable<>).MakeGenericType(arg);
+                if (iEnumerable.IsAssignableFrom(collectionType))
+                {
+                    return iEnumerable;
+                }
+            }
+        }
+
+        Type[] interfaces = collectionType.GetInterfaces();
+
+        foreach (Type iFace in interfaces)
+        {
+            Type? iEnumerable = FindIEnumerable(iFace);
+            if (iEnumerable != null) return iEnumerable;
+        }
+
+        if (collectionType.BaseType != null && collectionType.BaseType != typeof(object))
+        {
+            return FindIEnumerable(collectionType.BaseType);
+        }
+
+        return null;
     }
 }

--- a/src/External/O2Html/TypeCategory.cs
+++ b/src/External/O2Html/TypeCategory.cs
@@ -1,0 +1,8 @@
+namespace O2Html;
+
+public enum TypeCategory
+{
+    DotNetTypeWithStringRepresentation = 0,
+    SingleObject = 1,
+    Collection = 2
+}


### PR DESCRIPTION
Performance enhancements to serialization

- Serialization of objects to DOM elements sped up by 1.5x
- Serialization of DOM elements to HTML text sped up by 3x

Most important list of changes
- Cache HTMLConverter to use for specific type
- Cache TypeCategory for a specific type
- Cache property info of a specific type
- Cache element type of a specific collection type
- Pass object type instead of evaluating it everytime its needed
- Use a binary list to construct HTML text output instead of string joining
- Fixed infinite loop when serializing a Type