### PR TITLE
HTML serialization improvements

### DIFF
--- a/src/Apps/NetPad.Apps.App/App/src/core/@domain/api.ts
+++ b/src/Apps/NetPad.Apps.App/App/src/core/@domain/api.ts
@@ -4273,6 +4273,8 @@ export class ResultsOptions implements IResultsOptions {
     openOnRun!: boolean;
     textWrap!: boolean;
     font?: string | undefined;
+    maxSerializationDepth!: number;
+    maxCollectionSerializeLength!: number;
 
     constructor(data?: IResultsOptions) {
         if (data) {
@@ -4288,6 +4290,8 @@ export class ResultsOptions implements IResultsOptions {
             this.openOnRun = _data["openOnRun"];
             this.textWrap = _data["textWrap"];
             this.font = _data["font"];
+            this.maxSerializationDepth = _data["maxSerializationDepth"];
+            this.maxCollectionSerializeLength = _data["maxCollectionSerializeLength"];
         }
     }
 
@@ -4303,6 +4307,8 @@ export class ResultsOptions implements IResultsOptions {
         data["openOnRun"] = this.openOnRun;
         data["textWrap"] = this.textWrap;
         data["font"] = this.font;
+        data["maxSerializationDepth"] = this.maxSerializationDepth;
+        data["maxCollectionSerializeLength"] = this.maxCollectionSerializeLength;
         return data;
     }
 
@@ -4318,6 +4324,8 @@ export interface IResultsOptions {
     openOnRun: boolean;
     textWrap: boolean;
     font?: string | undefined;
+    maxSerializationDepth: number;
+    maxCollectionSerializeLength: number;
 }
 
 export class OmniSharpOptions implements IOmniSharpOptions {

--- a/src/Apps/NetPad.Apps.App/App/src/styles/_icons.scss
+++ b/src/Apps/NetPad.Apps.App/App/src/styles/_icons.scss
@@ -442,6 +442,11 @@ button > .icon-base {
     @extend .fa-align-left;
 }
 
+.results-serialization-settings-icon {
+    @extend %icon-base;
+    @extend .fa-cube;
+}
+
 .monaco-settings-icon {
     @extend %icon-base;
     @extend .fa-align-left;
@@ -508,7 +513,8 @@ button > .icon-base {
         color: #78909c;
     }
 
-    .run-icon {
+    .run-icon,
+    .results-serialization-settings-icon {
         color: #91b859;
     }
 
@@ -601,7 +607,8 @@ button > .icon-base {
         color: #5f7682;
     }
 
-    .run-icon {
+    .run-icon,
+    .results-serialization-settings-icon {
         color: #65ad4a;
     }
 

--- a/src/Apps/NetPad.Apps.App/App/src/windows/main/output-view/output-view.scss
+++ b/src/Apps/NetPad.Apps.App/App/src/windows/main/output-view/output-view.scss
@@ -57,6 +57,12 @@ output-view {
             color: red;
         }
 
+        .max-depth-reached {
+            font-style: italic;
+            font-size: $font-size - 1;
+            color: orange;
+        }
+
         .empty-collection {
             @extend %null;
         }

--- a/src/Apps/NetPad.Apps.App/App/src/windows/settings/general-settings/general-settings.html
+++ b/src/Apps/NetPad.Apps.App/App/src/windows/settings/general-settings/general-settings.html
@@ -72,7 +72,7 @@
             </div>
         </div>
 
-        <div class="sub-header">Indicators</div>
+        <div class="sub-header mt-3">Indicators</div>
         <div class="body">
             <div class="form-check">
                 <input id="showScriptRunStatusIndicatorInTab"

--- a/src/Apps/NetPad.Apps.App/App/src/windows/settings/omnisharp-settings/omnisharp-settings.html
+++ b/src/Apps/NetPad.Apps.App/App/src/windows/settings/omnisharp-settings/omnisharp-settings.html
@@ -1,7 +1,10 @@
-<p class="ps-3 text-muted">
-    <span class="warning-icon text-yellow"></span> Except where otherwise stated, changes to these settings
-    require restarting the OmniSharp server, per script, to take effect (ie. use the "Restart OmniSharp Server" command)
-</p>
+<div class="section text-muted d-flex">
+    <span class="warning-icon text-yellow me-3"></span>
+    <p class="flex-grow-1 m-0">
+        Except where otherwise stated, changes to these settings require restarting the OmniSharp server, per script,
+        to take effect (ie. execute <code>Restart OmniSharp Server</code> from the command palette). Alternatively, you can restart NetPad.
+    </p>
+</div>
 
 <div class="section">
     <div class="header">
@@ -30,9 +33,7 @@
                     <input type="text"
                            class="form-control"
                            id="omnisharpExePath"
-                           placeholder="/absolute/path/to/omnisharp/executable"
-                           value.bind="settings.editor.codeCompletion.provider.executablePath"
-                           disabled.bind="!settings.editor.codeCompletion.enabled">
+                           placeholder="/absolute/path/to/omnisharp/executable">
                     <div class="form-text">
                         If specified, the executable at the given path will be used. If left blank,
                         NetPad will download OmniSharp automatically.

--- a/src/Apps/NetPad.Apps.App/App/src/windows/settings/results-options-settings/results-options-settings.html
+++ b/src/Apps/NetPad.Apps.App/App/src/windows/settings/results-options-settings/results-options-settings.html
@@ -27,6 +27,58 @@
 
 <div class="section">
     <div class="header">
+        <i class="results-serialization-settings-icon"></i>
+        Serialization
+    </div>
+
+    <div class="body">
+        <div class="row">
+            <label class="col-3 col-form-label fw-bold"
+                   for="max-depth-input"
+                   title="The maximum depth to serialize.">
+                Max Depth
+            </label>
+            <div class="col-9">
+                <input type="number"
+                       id="max-depth-input"
+                       class="form-control d-inline-block"
+                       value.bind="settings.results.maxSerializationDepth"
+                       placeholder="Default: 64"
+                       min="0"
+                       max="1000"
+                       oninput="validity.valid||(value='');"
+                       style="max-width: 130px">
+                <span class="text-muted">
+                    (max: 1000)
+                </span>
+            </div>
+        </div>
+        <div class="row mt-2">
+            <label class="col-3 col-form-label fw-bold"
+                   for="max-collection-length"
+                   title="The maximum number of collection items to serialize.">
+                Max Collection Length
+            </label>
+            <div class="col-9">
+                <input type="number"
+                       id="max-collection-length"
+                       class="form-control d-inline-block"
+                       value.bind="settings.results.maxCollectionSerializeLength"
+                       placeholder="Default: 1000"
+                       min="0"
+                       max="100000"
+                       oninput="validity.valid||(value='');"
+                       style="max-width: 130px">
+                <span class="text-muted">
+                    (max: 100,000 | Recommended: 1000)
+                </span>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="section">
+    <div class="header">
         <i class="theme-icon"></i>
         Appearance
     </div>

--- a/src/Apps/NetPad.Apps.App/App/src/windows/settings/window.ts
+++ b/src/Apps/NetPad.Apps.App/App/src/windows/settings/window.ts
@@ -29,11 +29,31 @@ export class Window extends WindowBase {
     }
 
     public async save() {
+        if (!this.validate()) {
+            return;
+        }
+
         await this.settingService.update(this.editableSettings);
         window.close();
     }
 
     public cancel() {
         window.close();
+    }
+
+    private validate(): boolean {
+        let userValue: unknown = this.editableSettings.results.maxSerializationDepth;
+        if ((userValue !== 0 && !userValue) || isNaN(Number(userValue))) {
+            alert("Results > Serialization > Max Depth is required.");
+            return false;
+        }
+
+        userValue = this.editableSettings.results.maxCollectionSerializeLength;
+        if ((userValue !== 0 && !userValue) || isNaN(Number(userValue))) {
+            alert("Results > Serialization > Max Collection Length is required.");
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/Apps/NetPad.Apps.App/BackgroundServices/EventForwardToIpcBackgroundService.cs
+++ b/src/Apps/NetPad.Apps.App/BackgroundServices/EventForwardToIpcBackgroundService.cs
@@ -61,11 +61,11 @@ public class EventForwardToIpcBackgroundService : BackgroundService
                          // HACK: Script code could potentially be large (ex. a large base 64 string is used in code)
                          // which could cause race conditions where 2 subsequent push notifications could be sent
                          // and received on clients' out of order. While we can solve this with verifying message
-                         // order, since this is the only case currently where we need to worry about, opting to
+                         // order, since this is the only case currently where we need to worry about it, opting to
                          // just have the FE handle notifying itself when script code changes.
                          //
                          // This also means that if a script's code is changed outside of that client, the client will
-                         // know about that. This is a area we'd want to change to support of live code changes from
+                         // not know about it. This is an area we'd want to change to support of live code changes from
                          // multiple sources (ex. multiple users working on the same script)
                          && e.PropertyName != nameof(Script.Code)
                 );

--- a/src/Apps/NetPad.Apps.App/BackgroundServices/EventHandlerBackgroundService.cs
+++ b/src/Apps/NetPad.Apps.App/BackgroundServices/EventHandlerBackgroundService.cs
@@ -1,0 +1,29 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NetPad.Events;
+using NetPad.Html;
+
+namespace NetPad.BackgroundServices;
+
+public class EventHandlerBackgroundService : BackgroundService
+{
+    private readonly IEventBus _eventBus;
+
+    public EventHandlerBackgroundService(IEventBus eventBus, ILoggerFactory loggerFactory) : base(loggerFactory)
+    {
+        _eventBus = eventBus;
+    }
+
+    protected override Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _eventBus.Subscribe<SettingsUpdatedEvent>(ev =>
+        {
+            HtmlSerializer.UpdateHtmlSerializerSettings(ev.Settings.Results.MaxSerializationDepth, ev.Settings.Results.MaxCollectionSerializeLength);
+
+            return Task.CompletedTask;
+        });
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Apps/NetPad.Apps.App/Startup.cs
+++ b/src/Apps/NetPad.Apps.App/Startup.cs
@@ -108,6 +108,7 @@ public class Startup
         services.AddSingleton(pluginManager);
 
         // Hosted services
+        services.AddHostedService<EventHandlerBackgroundService>();
         services.AddHostedService<EventForwardToIpcBackgroundService>();
         services.AddHostedService<ScriptEnvironmentBackgroundService>();
         services.AddHostedService<ScriptsFileWatcherBackgroundService>();

--- a/src/Core/NetPad.Domain/Configuration/ResultsOptions.cs
+++ b/src/Core/NetPad.Domain/Configuration/ResultsOptions.cs
@@ -14,6 +14,8 @@ public class ResultsOptions : ISettingsOptions
     [JsonInclude] public bool OpenOnRun { get; private set; }
     [JsonInclude] public bool TextWrap { get; private set; }
     [JsonInclude] public string? Font { get; private set; }
+    [JsonInclude] public uint MaxSerializationDepth { get; private set; }
+    [JsonInclude] public uint MaxCollectionSerializeLength { get; private set; }
 
     public ResultsOptions SetOpenOnRun(bool openOnRun)
     {
@@ -33,7 +35,31 @@ public class ResultsOptions : ISettingsOptions
         return this;
     }
 
+    public ResultsOptions SetMaxSerializationDepth(uint maxSerializationDepth)
+    {
+        if (maxSerializationDepth > 1000)
+        {
+            maxSerializationDepth = 1000;
+        }
+
+        MaxSerializationDepth = maxSerializationDepth;
+        return this;
+    }
+
+    public ResultsOptions SetMaxCollectionSerializeLengthDepth(uint maxCollectionSerializeLength)
+    {
+        if (maxCollectionSerializeLength > 100000)
+        {
+            maxCollectionSerializeLength = 100000;
+        }
+
+        MaxCollectionSerializeLength = maxCollectionSerializeLength;
+        return this;
+    }
+
     public void DefaultMissingValues()
     {
+        if (MaxSerializationDepth > 1000) MaxSerializationDepth = 1000;
+        if (MaxCollectionSerializeLength > 100000) MaxCollectionSerializeLength = 100000;
     }
 }

--- a/src/Core/NetPad.Domain/Configuration/Settings.cs
+++ b/src/Core/NetPad.Domain/Configuration/Settings.cs
@@ -90,7 +90,9 @@ public class Settings : ISettingsOptions
         Results
             .SetOpenOnRun(options.OpenOnRun)
             .SetTextWrap(options.TextWrap)
-            .SetFont(options.Font);
+            .SetFont(options.Font)
+            .SetMaxSerializationDepth(options.MaxSerializationDepth)
+            .SetMaxCollectionSerializeLengthDepth(options.MaxCollectionSerializeLength);
 
         return this;
     }

--- a/src/External/O2Html.Tests/HtmlConvertTests.cs
+++ b/src/External/O2Html.Tests/HtmlConvertTests.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using O2Html.Converters;
+using Xunit;
+
+namespace O2Html.Tests;
+
+public class HtmlConvertTests
+{
+    private static readonly HtmlSerializerSettings _htmlSerializerSettings = new()
+    {
+        ReferenceLoopHandling = ReferenceLoopHandling.IgnoreAndSerializeCyclicReference
+    };
+
+    [Theory]
+    [MemberData(nameof(TestData.All), MemberType = typeof(TestData))]
+    public void HtmlSerailizerSuccessfullyConverts(object? value)
+    {
+        var node = HtmlConvert.Serialize(value, _htmlSerializerSettings);
+        _ = node.ToHtml();
+    }
+
+    public static IEnumerable<object?[]> GetConverterTestData()
+    {
+        var result = new List<object?[]>();
+
+        void AddData(IEnumerable<object?[]> data, Type converterType)
+        {
+            foreach (var item in data)
+            {
+                result!.Add(item.Append(converterType).ToArray());
+            }
+        }
+
+        AddData(TestData.RepresentedAsStringsValues(), typeof(DotNetTypeWithStringRepresentationHtmlConverter));
+        AddData(TestData.ObjectValues(), typeof(ObjectHtmlConverter));
+        AddData(TestData.CollectionValues(), typeof(CollectionHtmlConverter));
+        AddData(TestData.TwoDimensionalArrayValues(), typeof(TwoDimensionalArrayHtmlConverter));
+        AddData(TestData.TupleValues(), typeof(TupleHtmlConverter));
+        AddData(TestData.MemoryValues(), typeof(MemoryHtmlConverter));
+        AddData(TestData.XmlNodeValues(), typeof(XmlNodeHtmlConverter));
+        AddData(TestData.XNodeValues(), typeof(XNodeHtmlConverter));
+        AddData(TestData.FileSystemInfoValues(), typeof(FileSystemInfoHtmlConverter));
+        AddData(TestData.DataTableValues(), typeof(DataTableHtmlConverter));
+        AddData(TestData.DataSetValues(), typeof(DataSetHtmlConverter));
+
+        return result;
+    }
+
+    [Theory]
+    [MemberData(nameof(GetConverterTestData))]
+    public void HtmlSerailizerGetsCorrectConverter(object? value, Type expectedConverterType)
+    {
+        var converter = HtmlSerializer.Create().GetConverter(value?.GetType() ?? typeof(object));
+
+        Assert.NotNull(converter);
+        Assert.StrictEqual(expectedConverterType, converter.GetType());
+    }
+}

--- a/src/External/O2Html.Tests/O2Html.Tests.csproj
+++ b/src/External/O2Html.Tests/O2Html.Tests.csproj
@@ -24,4 +24,8 @@
         <ProjectReference Include="..\O2Html\O2Html.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <Compile Remove="Extensions.cs" />
+    </ItemGroup>
+
 </Project>

--- a/src/External/O2Html.Tests/SerializationScopeTests.cs
+++ b/src/External/O2Html.Tests/SerializationScopeTests.cs
@@ -1,0 +1,78 @@
+using System.Linq;
+using Xunit;
+
+namespace O2Html.Tests;
+
+public class SerializationScopeTests
+{
+    [Fact]
+    public void CheckAlreadySerializedOrAdd_ReturnsFalse_ForUnseenObject()
+    {
+        var serializationScope = new SerializationScope(0);
+        var person = new Person("John", 30);
+
+        var alreadySerialized = serializationScope.CheckAlreadySerializedOrAdd(person);
+
+        Assert.False(alreadySerialized);
+        Assert.Single(serializationScope.SerializedObjects);
+        Assert.Same(person, serializationScope.SerializedObjects.Single());
+    }
+
+    [Fact]
+    public void CheckAlreadySerializedOrAdd_ReturnsTrue_ForSeenObject()
+    {
+        var serializationScope = new SerializationScope(0);
+        var person = new Person("John", 30);
+        serializationScope.CheckAlreadySerializedOrAdd(person);
+
+        var alreadySerialized = serializationScope.CheckAlreadySerializedOrAdd(person);
+
+        Assert.True(alreadySerialized);
+        Assert.Single(serializationScope.SerializedObjects);
+        Assert.Same(person, serializationScope.SerializedObjects.Single());
+    }
+
+    [Fact]
+    public void CheckAlreadySerializedOrAdd_DoesNotAddSeenObject()
+    {
+        var serializationScope = new SerializationScope(0);
+        var person = new Person("John", 30);
+        serializationScope.CheckAlreadySerializedOrAdd(person);
+
+        var alreadySerialized = serializationScope.CheckAlreadySerializedOrAdd(person);
+
+        Assert.True(alreadySerialized);
+        Assert.Single(serializationScope.SerializedObjects);
+        Assert.Same(person, serializationScope.SerializedObjects.Single());
+    }
+
+    [Fact]
+    public void CheckAlreadySerializedOrAdd_UsesReferenceEquality()
+    {
+        var serializationScope = new SerializationScope(0);
+        var product1 = new Product("Coffee Mug", 10);
+        var product2 = new Product("Coffee Mug", 10);
+        serializationScope.CheckAlreadySerializedOrAdd(product1);
+
+        var alreadySerialized = serializationScope.CheckAlreadySerializedOrAdd(product2);
+
+        Assert.False(alreadySerialized, "Considers product2 as unseen");
+        Assert.Equal(2, serializationScope.SerializedObjects.Count);
+        Assert.Same(product1, serializationScope.SerializedObjects.ElementAt(0));
+        Assert.Same(product2, serializationScope.SerializedObjects.ElementAt(1));
+    }
+
+    class Person
+    {
+        public Person(string name, int age)
+        {
+            Name = name;
+            Age = age;
+        }
+
+        public string Name { get; }
+        public int Age { get; }
+    }
+
+    record Product(string Name, decimal Price);
+}

--- a/src/External/O2Html.Tests/TestData.cs
+++ b/src/External/O2Html.Tests/TestData.cs
@@ -1,0 +1,274 @@
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Data;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Net.Sockets;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace O2Html.Tests;
+
+public class TestData
+{
+    public static IEnumerable<object?[]> RepresentedAsStringsValues()
+    {
+        return new[]
+        {
+            new object[] { "value" },
+            new object[] { 'v' },
+            new object[] { 1 },
+            new object[] { 2.2 },
+            new object[] { 3.2m },
+            new object[] { 4.2f },
+            new object[] { 5L },
+            new object[] { (int?)1 },
+            new object[] { (double?)2.2 },
+            new object[] { (decimal?)3.2m },
+            new object[] { (float?)4.2f },
+            new object[] { (long?)5L },
+            new object[] { true },
+            new object[] { (byte)6 },
+            new object[] { (sbyte)7 },
+            new object[] { (nint)8 },
+            new object[] { Guid.NewGuid() },
+            new object[] { DateTime.UtcNow },
+            new object[] { DateTime.UtcNow - DateTime.UtcNow.AddHours(1) },
+            new object[] { DateOnly.MinValue },
+            new object[] { TimeOnly.MinValue },
+            new object[] { DateTimeOffset.UtcNow },
+            new object[] { BindingFlags.Public },
+            new object[] { BindingFlags.Public | BindingFlags.Instance },
+            new object[] { JsonCommentHandling.Allow },
+            new object[] { new FormattableType() },
+            new object[] { new Exception("Some error") },
+            new object[] { typeof(string) },
+            new object[] { Version.Parse("1.2.3.4") },
+        };
+    }
+
+    public static IEnumerable<object?[]> ObjectValues()
+    {
+        return new[]
+        {
+            new object[] { null! },
+            new object[] { new { Name = "John", Age = 32 } },
+            new object[] { new Customer("John", 32) },
+            new object[] { new Product("Computer", 995.5m) },
+            new object[] { new Uri("https://www.github.com") },
+            new object[] { DBNull.Value },
+            new object[] { CultureInfo.CurrentCulture },
+            new object[] { new MemoryStream() },
+            new object[] { StringComparer.Ordinal },
+            new object[] { new Action<int>(i => { ++i; }) },
+            new object[] { Task.FromResult(new Customer("name", 33)) },
+            new object[] { JsonDocument.Parse(@"[{""Name"": ""John Smith"", ""Age"": 33}]") },
+            new object[] { new Regex(@"\b(?<word>\w+)\s+(\k<word>)\b") },
+            new object[] { new Regex(@"\b(?<word>\w+)\s+(\k<word>)\b").Matches("The the quick brown fox  fox jumps over the lazy dog dog.")[0].Groups[0] },
+            new object[] { Process.GetCurrentProcess() },
+            new object[] { Assembly.GetExecutingAssembly() },
+            new object[] { new System.Net.Mail.MailAddress("test@test.com", "Test Man") },
+            new object[] { new System.Web.HttpUtility() },
+#pragma warning disable SYSLIB0026
+            new object[] { new System.Security.Cryptography.X509Certificates.X509Certificate() },
+#pragma warning restore SYSLIB0026
+            new object[] { new System.Net.NetworkCredential("username", "password") },
+            new object[] { new System.Net.NetworkCredential("username", "password").SecurePassword },
+            new object[] { new Stopwatch() },
+            new object[] { new System.Timers.Timer() },
+            new object[] { new System.Threading.Timer(_ => { }) },
+            new object[] { new Socket(SocketType.Stream, ProtocolType.Tcp) },
+        };
+    }
+
+    public static IEnumerable<object?[]> CollectionValues()
+    {
+        return new[]
+        {
+            new object[] { new List<string> { "one", "two" } },
+            new object[] { new[] { "one", "two" } },
+            new object[] { new HashSet<string> { "one", "two" } },
+            new object[] { new Dictionary<string, int> { { "one", 1 }, { "two", 2 } } },
+            new object[] { new ConcurrentDictionary<string, int>(new Dictionary<string, int> { { "one", 1 }, { "two", 2 } }) },
+            new object[] { new Queue<string>(new[] { "one", "two" }) },
+            new object[] { new Stack<string>(new[] { "one", "two" }) },
+            new object[] { new BitArray(5, false) },
+            new object[] { new byte[] { 5, 3 } },
+            new object[] { new ObservableCollection<string> { "str", "str 2" } },
+            new object[] { new Regex(@"\b(?<word>\w+)\s+(\k<word>)\b").Matches("The the quick brown fox  fox jumps over the lazy dog dog.") },
+            new object[] { new Regex(@"\b(?<word>\w+)\s+(\k<word>)\b").Matches("The the quick brown fox  fox jumps over the lazy dog dog.")[0].Groups },
+        };
+    }
+
+    public static IEnumerable<object?[]> TwoDimensionalArrayValues()
+    {
+        return new[]
+        {
+            new object[] { new[,] { { 1, 2 }, { 3, 4 }, { 5, 6 }, { 7, 8 } } },
+            new object[] { new[,] { { "one", "two" }, { "three", "four" } } },
+            new object[] { new[,] { { new Customer(), new Customer() }, { new Customer(), new Customer() } } },
+        };
+    }
+
+    public static IEnumerable<object?[]> TupleValues()
+    {
+        return new[]
+        {
+            new object[] { (1, 2) },
+            new object[] { (1, 2, 3, 4) },
+            new object[] { ("one", "two") },
+            new object[] { (new Customer(), new Customer(), new Customer(), new Customer()) },
+            new object[] { (new Customer(), 4.3m, new DateTime(), "str") },
+        };
+    }
+
+    public static IEnumerable<object?[]> MemoryValues()
+    {
+        return new[]
+        {
+            new object[] { new Memory<int>(new[] { 2, 4, 6 }) },
+            new object[] { new ReadOnlyMemory<string>(new[] { "one", "two" }) },
+        };
+    }
+
+    public static IEnumerable<object?[]> XmlNodeValues()
+    {
+        var xmlDocument = new XmlDocument();
+        xmlDocument.InnerXml = GetXml();
+
+        return new[]
+        {
+            new object[] { xmlDocument },
+        };
+    }
+
+    public static IEnumerable<object?[]> XNodeValues()
+    {
+        return new[]
+        {
+            new object[] { XDocument.Parse(GetXml()) },
+            new object[] { XElement.Parse(GetXml()) },
+        };
+    }
+
+    public static IEnumerable<object?[]> FileSystemInfoValues()
+    {
+        return new[]
+        {
+            new object[] { new FileInfo("/etc/os-release") },
+            new object[] { new DirectoryInfo("/etc") },
+        };
+    }
+
+    public static IEnumerable<object?[]> DataTableValues()
+    {
+        return new[]
+        {
+            new object[] { GetDataTable("Table 1") },
+        };
+    }
+
+    public static IEnumerable<object?[]> DataSetValues()
+    {
+        var dataSet = new DataSet("Set name");
+
+        dataSet.Tables.Add(GetDataTable("Table 1"));
+        dataSet.Tables.Add(GetDataTable("Table 2"));
+        dataSet.Tables.Add(GetDataTable("Table 3"));
+
+        return new[]
+        {
+            new object[] { dataSet },
+        };
+    }
+
+    public static IEnumerable<object?[]> All()
+    {
+        var data = new List<object?[]>();
+
+        data.AddRange(RepresentedAsStringsValues());
+        data.AddRange(ObjectValues());
+        data.AddRange(CollectionValues());
+        data.AddRange(TwoDimensionalArrayValues());
+        data.AddRange(TupleValues());
+        data.AddRange(MemoryValues());
+        data.AddRange(XmlNodeValues());
+        data.AddRange(XNodeValues());
+        data.AddRange(FileSystemInfoValues());
+        data.AddRange(DataTableValues());
+        data.AddRange(DataSetValues());
+
+        return data;
+    }
+
+
+    private static string GetXml()
+    {
+        return "<root><children><child attr=\"test\">Value 1</child><child attr=\"test\"></child></children></root>";
+    }
+
+    private static DataTable GetDataTable(string tableName)
+    {
+        var dt = new DataTable(tableName);
+
+        dt.Columns.Add("string", typeof(string));
+        dt.Columns.Add("integer", typeof(int));
+        dt.Columns.Add("double", typeof(int));
+        dt.Columns.Add("Nullable(decimal)", typeof(decimal));
+        dt.Columns.Add("Customer", typeof(Customer));
+        dt.Columns.Add("XNode", typeof(XNode));
+        dt.Columns.Add("Tuple", typeof(ValueTuple<int, Customer>));
+        dt.Columns.Add("2-D array", typeof(float[,]));
+
+        var row = dt.NewRow();
+        dt.Rows.Add(row);
+
+        row.ItemArray = new object?[]
+        {
+            "str",
+            4,
+            5.6,
+            (decimal?)null,
+            new Customer("name", 33),
+            XElement.Parse(GetXml()),
+            (5, new Customer()),
+            new[,] { { 3.5F, 2F }, { 0F, 1.1F } }
+        };
+
+        return dt;
+    }
+
+    class FormattableType : IFormattable
+    {
+        public string ToString(string? format, IFormatProvider? formatProvider)
+        {
+            return "formatted string representation";
+        }
+    }
+
+    class Customer
+    {
+        public Customer()
+        {
+        }
+
+        public Customer(string name, int age)
+        {
+            Name = name;
+            Age = age;
+        }
+
+        public string? Name { get; }
+        public int? Age { get; }
+    }
+
+    record Product(string Name, decimal Price);
+}

--- a/src/External/O2Html/Common/LazyEnumerable.cs
+++ b/src/External/O2Html/Common/LazyEnumerable.cs
@@ -12,15 +12,14 @@ internal class LazyEnumerationResult
 
 internal static class LazyEnumerable
 {
-    public static LazyEnumerationResult Enumerate<T>(IEnumerable<T> collection, int? maxItemsToEnumerate, Action<T?, int> action)
+    public static LazyEnumerationResult Enumerate<T>(IEnumerable<T> collection, uint? maxItemsToEnumerate, Action<T?, uint> action)
     {
         var result = new LazyEnumerationResult();
 
-        int currentElementIndex = -1;
+        uint currentElementIndex = 0;
 
         foreach (T element in collection)
         {
-            ++currentElementIndex;
             if (result.ElementsEnumerated + 1 > maxItemsToEnumerate)
             {
                 result.CollectionLengthExceedsMax = true;
@@ -29,25 +28,25 @@ internal static class LazyEnumerable
 
             action(element, currentElementIndex);
             ++result.ElementsEnumerated;
+            ++currentElementIndex;
         }
 
         return result;
     }
 
-    public static LazyEnumerationResult Enumerate(IEnumerable collection, int? maxItemsToEnumerate, Action<object?, int> action)
+    public static LazyEnumerationResult Enumerate(IEnumerable collection, uint? maxItemsToEnumerate, Action<object?, uint> action)
     {
         return Enumerate<object>(collection, maxItemsToEnumerate, action);
     }
 
-    public static LazyEnumerationResult Enumerate<T>(IEnumerable collection, int? maxItemsToEnumerate, Action<T?, int> action)
+    public static LazyEnumerationResult Enumerate<T>(IEnumerable collection, uint? maxItemsToEnumerate, Action<T?, uint> action)
     {
         var result = new LazyEnumerationResult();
 
-        int currentElementIndex = -1;
+        uint currentElementIndex = 0;
 
         foreach (T element in collection)
         {
-            ++currentElementIndex;
             if (result.ElementsEnumerated + 1 > maxItemsToEnumerate)
             {
                 result.CollectionLengthExceedsMax = true;
@@ -57,6 +56,7 @@ internal static class LazyEnumerable
 
             action(element, currentElementIndex);
             ++result.ElementsEnumerated;
+            ++currentElementIndex;
         }
 
         return result;

--- a/src/External/O2Html/Common/ReferenceEqualityComparer.cs
+++ b/src/External/O2Html/Common/ReferenceEqualityComparer.cs
@@ -1,0 +1,63 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Original source from https://github.com/dotnet/runtime/blob/79823768e461a865019d7bdf70cfe0fcbeb99288/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/ReferenceEqualityComparer.cs
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace O2Html.Common;
+
+/// <summary>
+/// An <see cref="IEqualityComparer{Object}"/> that uses reference equality (<see cref="object.ReferenceEquals(object?, object?)"/>)
+/// instead of value equality (<see cref="object.Equals(object?)"/>) when comparing two object instances.
+/// </summary>
+/// <remarks>
+/// The <see cref="ReferenceEqualityComparer"/> type cannot be instantiated. Instead, use the <see cref="Instance"/> property
+/// to access the singleton instance of this type.
+/// </remarks>
+internal sealed class ReferenceEqualityComparer : IEqualityComparer<object?>, IEqualityComparer
+{
+    private ReferenceEqualityComparer()
+    {
+    }
+
+    /// <summary>
+    /// Gets the singleton <see cref="ReferenceEqualityComparer"/> instance.
+    /// </summary>
+    public static ReferenceEqualityComparer Instance { get; } = new ReferenceEqualityComparer();
+
+    /// <summary>
+    /// Determines whether two object references refer to the same object instance.
+    /// </summary>
+    /// <param name="x">The first object to compare.</param>
+    /// <param name="y">The second object to compare.</param>
+    /// <returns>
+    /// <see langword="true"/> if both <paramref name="x"/> and <paramref name="y"/> refer to the same object instance
+    /// or if both are <see langword="null"/>; otherwise, <see langword="false"/>.
+    /// </returns>
+    /// <remarks>
+    /// This API is a wrapper around <see cref="object.ReferenceEquals(object?, object?)"/>.
+    /// It is not necessarily equivalent to calling <see cref="object.Equals(object?, object?)"/>.
+    /// </remarks>
+    public new bool Equals(object? x, object? y) => ReferenceEquals(x, y);
+
+    /// <summary>
+    /// Returns a hash code for the specified object. The returned hash code is based on the object
+    /// identity, not on the contents of the object.
+    /// </summary>
+    /// <param name="obj">The object for which to retrieve the hash code.</param>
+    /// <returns>A hash code for the identity of <paramref name="obj"/>.</returns>
+    /// <remarks>
+    /// This API is a wrapper around <see cref="RuntimeHelpers.GetHashCode(object)"/>.
+    /// It is not necessarily equivalent to calling <see cref="object.GetHashCode()"/>.
+    /// </remarks>
+    public int GetHashCode(object? obj)
+    {
+        // Depending on target framework, RuntimeHelpers.GetHashCode might not be annotated
+        // with the proper nullability attribute. We'll suppress any warning that might
+        // result.
+        return RuntimeHelpers.GetHashCode(obj!);
+    }
+}

--- a/src/External/O2Html/Converters/CollectionHtmlConverter.cs
+++ b/src/External/O2Html/Converters/CollectionHtmlConverter.cs
@@ -69,7 +69,10 @@ public class CollectionHtmlConverter : HtmlConverter
         var enumerationResult = LazyEnumerable.Enumerate(enumerable, htmlSerializer.SerializerSettings.MaxCollectionSerializeLength, (element, _) =>
         {
             var tr = table.Body.AddAndGetElement("tr");
+
             htmlSerializer.SerializeWithinTableRow(tr, element, elementType, serializationScope);
+
+            if (!tr.Children.Any()) table.Body.RemoveChild(tr);
         });
 
         string headerRowText = GetHeaderRowText(

--- a/src/External/O2Html/Converters/CollectionHtmlConverter.cs
+++ b/src/External/O2Html/Converters/CollectionHtmlConverter.cs
@@ -190,6 +190,6 @@ public class CollectionHtmlConverter : HtmlConverter
     private IEnumerable ToEnumerable<T>(T obj)
     {
         return obj as IEnumerable ??
-               throw new InvalidCastException($"Cannot cast {nameof(obj)} to {nameof(IEnumerable)}");
+               throw new InvalidCastException($"Cannot cast {nameof(obj)} of type {obj!.GetType()} to {nameof(IEnumerable)}");
     }
 }

--- a/src/External/O2Html/Converters/DataTableHtmlConverter.cs
+++ b/src/External/O2Html/Converters/DataTableHtmlConverter.cs
@@ -36,11 +36,13 @@ public class DataTableHtmlConverter : HtmlConverter
         {
             var tr = table.Body.AddAndGetRow();
 
+            int ixItem = 0;
+
             foreach (var item in row!.ItemArray)
             {
                 var td = tr.AddAndGetElement("td");
 
-                var itemType = item?.GetType() ?? typeof(object);
+                var itemType = item?.GetType() ?? dataTable.Columns[ixItem].DataType;
 
                 if (item == null || itemType == typeof(DBNull))
                 {
@@ -50,6 +52,8 @@ public class DataTableHtmlConverter : HtmlConverter
                 {
                     td.AddChild(htmlSerializer.Serialize(item, itemType, serializationScope));
                 }
+
+                ixItem++;
             }
         });
 

--- a/src/External/O2Html/Converters/FileSystemInfoHtmlConverter.cs
+++ b/src/External/O2Html/Converters/FileSystemInfoHtmlConverter.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+namespace O2Html.Converters;
+
+public class FileSystemInfoHtmlConverter : ObjectHtmlConverter
+{
+    public override bool CanConvert(HtmlSerializer htmlSerializer, Type type)
+    {
+        return typeof(FileSystemInfo).IsAssignableFrom(type);
+    }
+
+    private static readonly HashSet<string> _serializableProperties = new()
+    {
+        nameof(FileSystemInfo.Attributes),
+        nameof(FileSystemInfo.FullName),
+        nameof(FileSystemInfo.Name),
+        nameof(FileSystemInfo.Extension),
+        nameof(FileSystemInfo.Exists),
+        nameof(FileSystemInfo.CreationTime),
+        nameof(FileSystemInfo.CreationTimeUtc),
+        nameof(FileSystemInfo.LastAccessTime),
+        nameof(FileSystemInfo.LastAccessTimeUtc),
+        nameof(FileSystemInfo.LastWriteTime),
+        nameof(FileSystemInfo.LastWriteTimeUtc),
+#if NET6_0_OR_GREATER
+        nameof(FileSystemInfo.LinkTarget),
+#endif
+#if NET7_0_OR_GREATER
+        nameof(FileSystemInfo.UnixFileMode),
+#endif
+    };
+
+    protected override PropertyInfo[] GetReadableProperties(HtmlSerializer htmlSerializer, Type type)
+    {
+        return base.GetReadableProperties(htmlSerializer, type)
+            .Where(p => _serializableProperties.Contains(p.Name))
+            .ToArray();
+    }
+}

--- a/src/External/O2Html/Converters/MemoryHtmlConverter.cs
+++ b/src/External/O2Html/Converters/MemoryHtmlConverter.cs
@@ -1,0 +1,40 @@
+#if NETSTANDARD2_1 || NETCOREAPP2_1_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using O2Html.Dom;
+using O2Html.Dom.Elements;
+
+namespace O2Html.Converters;
+
+public class MemoryHtmlConverter : CollectionHtmlConverter
+{
+    private const string ToArrayMethodName = "ToArray";
+    private static readonly HashSet<Type> _canConvertTypes = new()
+    {
+        typeof(Memory<>),
+        typeof(ReadOnlyMemory<>),
+    };
+
+    public override bool CanConvert(HtmlSerializer htmlSerializer, Type type)
+    {
+        return type.IsGenericType && _canConvertTypes.Contains(type.GetGenericTypeDefinition());
+    }
+
+    protected override (Node node, int? collectionLength) Convert<T>(T obj, Type type, SerializationScope serializationScope, HtmlSerializer htmlSerializer)
+    {
+        if (obj == null)
+            return (new Null(htmlSerializer.SerializerSettings.CssClasses.Null), null);
+
+        var method = type.GetMethod(ToArrayMethodName, BindingFlags.Public | BindingFlags.Instance);
+
+        if (method == null)
+        {
+            throw new Exception($"Cannot serialize type {type}. {ToArrayMethodName} method not found.");
+        }
+
+        Array array = (Array)method.Invoke(obj, Array.Empty<object>());
+        return base.Convert(array, array.GetType(), serializationScope, htmlSerializer);
+    }
+}
+#endif

--- a/src/External/O2Html/Converters/ObjectHtmlConverter.cs
+++ b/src/External/O2Html/Converters/ObjectHtmlConverter.cs
@@ -31,7 +31,7 @@ public class ObjectHtmlConverter : HtmlConverter
             .WithText(type.GetReadableName())
             .WithTitle(type.GetReadableName(true));
 
-        var properties = htmlSerializer.GetReadableProperties(type);
+        PropertyInfo[] properties = GetReadableProperties(htmlSerializer, type);
 
         foreach (var property in properties)
         {
@@ -82,6 +82,11 @@ public class ObjectHtmlConverter : HtmlConverter
                 .WithAddClass(htmlSerializer.SerializerSettings.CssClasses.PropertyValue)
                 .AddChild(htmlSerializer.Serialize(value, propertyType, serializationScope));
         }
+    }
+
+    protected virtual PropertyInfo[] GetReadableProperties(HtmlSerializer htmlSerializer, Type type)
+    {
+        return htmlSerializer.GetReadableProperties(type);
     }
 
     private object? GetPropertyValue<T>(PropertyInfo property, ref T? obj)

--- a/src/External/O2Html/Dom/Elements/MaxDepthReached.cs
+++ b/src/External/O2Html/Dom/Elements/MaxDepthReached.cs
@@ -1,0 +1,10 @@
+namespace O2Html.Dom.Elements;
+
+public class MaxDepthReached : Element
+{
+    public MaxDepthReached(string cssClass) : base("span")
+    {
+        AddText("max depth reached");
+        this.WithAddClass(cssClass);
+    }
+}

--- a/src/External/O2Html/Dom/Node.cs
+++ b/src/External/O2Html/Dom/Node.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics.Contracts;
 
 namespace O2Html.Dom;
 
@@ -12,11 +13,21 @@ public abstract class Node
     public NodeType Type { get; }
     public Element? Parent { get; internal set; }
 
+    [Pure]
     public abstract string ToHtml(Formatting? formatting = null);
+
     public abstract void ToHtml(List<byte> output, Formatting? formatting = null);
 
     public void Delete()
     {
         Parent?.RemoveChild(this);
+    }
+
+    /// <summary>
+    /// Alias to <see cref="ToHtml(System.Nullable{O2Html.Formatting})"/>.
+    /// </summary>
+    public override string ToString()
+    {
+        return ToHtml();
     }
 }

--- a/src/External/O2Html/HtmlSerializer.cs
+++ b/src/External/O2Html/HtmlSerializer.cs
@@ -51,7 +51,7 @@ public sealed class HtmlSerializer
         Converters.Add(new ObjectHtmlConverter());
     }
 
-    public HtmlSerializerSettings SerializerSettings { get; }
+    internal HtmlSerializerSettings SerializerSettings { get; }
 
     public List<HtmlConverter> Converters { get; }
 
@@ -77,7 +77,7 @@ public sealed class HtmlSerializer
         converter.WriteHtmlWithinTableRow(tr, obj, type, serializationScope, this);
     }
 
-    public TypeCategory GetTypeCategory(Type type)
+    internal TypeCategory GetTypeCategory(Type type)
     {
         if (_typeCategoryCache.TryGetValue(type, out var category))
             return category;
@@ -93,7 +93,7 @@ public sealed class HtmlSerializer
         return category;
     }
 
-    public PropertyInfo[] GetReadableProperties(Type type)
+    internal PropertyInfo[] GetReadableProperties(Type type)
     {
         if (_typePropertyCache.TryGetValue(type, out var propertyInfos))
             return propertyInfos;
@@ -118,7 +118,7 @@ public sealed class HtmlSerializer
         return elementType;
     }
 
-    private HtmlConverter? GetConverter(Type type)
+    internal HtmlConverter? GetConverter(Type type)
     {
         if (_typeConverterCache.TryGetValue(type, out var match))
             return match;

--- a/src/External/O2Html/HtmlSerializer.cs
+++ b/src/External/O2Html/HtmlSerializer.cs
@@ -44,6 +44,9 @@ public sealed class HtmlSerializer
 #if NETSTANDARD2_1 || NETCOREAPP3_0_OR_GREATER
         Converters.Add(new TupleHtmlConverter());
 #endif
+#if NETSTANDARD2_1 || NETCOREAPP2_1_OR_GREATER
+        Converters.Add(new MemoryHtmlConverter());
+#endif
         Converters.Add(new CollectionHtmlConverter());
         Converters.Add(new ObjectHtmlConverter());
     }

--- a/src/External/O2Html/HtmlSerializer.cs
+++ b/src/External/O2Html/HtmlSerializer.cs
@@ -34,6 +34,7 @@ public sealed class HtmlSerializer
 
         // Add default converters in this order, first converter in list
         // that can convert object takes precedence
+        Converters.Add(new FileSystemInfoHtmlConverter());
         Converters.Add(new TwoDimensionalArrayHtmlConverter());
         Converters.Add(new DataSetHtmlConverter());
         Converters.Add(new DataTableHtmlConverter());

--- a/src/External/O2Html/HtmlSerializer.cs
+++ b/src/External/O2Html/HtmlSerializer.cs
@@ -13,6 +13,7 @@ namespace O2Html;
 
 public sealed class HtmlSerializer
 {
+    private static readonly HtmlSerializerSettings _htmlSerializerSettings = new();
     private static readonly ConcurrentDictionary<Type, HtmlConverter?> _typeConverterCache = new();
     private static readonly ConcurrentDictionary<Type, TypeCategory> _typeCategoryCache = new();
     private static readonly ConcurrentDictionary<Type, PropertyInfo[]> _typePropertyCache = new();
@@ -20,17 +21,11 @@ public sealed class HtmlSerializer
 
     public HtmlSerializer(HtmlSerializerSettings? serializerSettings = null)
     {
-        SerializerSettings = serializerSettings ?? new HtmlSerializerSettings();
+        SerializerSettings = serializerSettings ?? _htmlSerializerSettings;
         Converters = new List<HtmlConverter>();
 
-        if (SerializerSettings.Converters?.Any() == true)
-        {
-            // Insert settings converters at the beginning so they take precedence
-            foreach (var converter in SerializerSettings.Converters)
-            {
-                Converters.Add(converter);
-            }
-        }
+        // Insert settings converters at the beginning so they take precedence
+        Converters.AddRange(SerializerSettings.Converters);
 
         // Add default converters in this order, first converter in list
         // that can convert object takes precedence

--- a/src/External/O2Html/HtmlSerializerSettings.cs
+++ b/src/External/O2Html/HtmlSerializerSettings.cs
@@ -5,6 +5,8 @@ namespace O2Html;
 public class HtmlSerializerSettings
 {
     internal const ReferenceLoopHandling DefaultReferenceLoopHandling = ReferenceLoopHandling.Error;
+    private const uint DefaultMaxDepth = 64;
+    private uint _maxDepth = DefaultMaxDepth;
 
     public HtmlSerializerSettings()
     {
@@ -12,64 +14,93 @@ public class HtmlSerializerSettings
         CssClasses = new CssClasses();
     }
 
+    /// <summary>
+    /// How reference loops should be handled. (Default: Error)
+    /// </summary>
     public ReferenceLoopHandling ReferenceLoopHandling { get; set; } = DefaultReferenceLoopHandling;
 
-    public List<HtmlConverter> Converters { get; }
-    public CssClasses CssClasses { get; }
-
     /// <summary>
-    /// If true, will not serialize empty collections that are not the root object being serialized. Default is false.
+    /// If true, empty collections, that are not the root object being serialized, will not be serialized. (Default: false)
     /// </summary>
     public bool DoNotSerializeNonRootEmptyCollections { get; set; }
 
     /// <summary>
-    /// If set, only this number of items will be serialized when serializing collections.
+    /// If set, only this number of items will be serialized when serializing collections. (Default: null)
     /// </summary>
-    public int? MaxCollectionSerializeLength { get; set; }
+    public uint? MaxCollectionSerializeLength { get; set; }
+
+    /// <summary>
+    /// The max serialization depth. (Default: 64)
+    /// </summary>
+    public uint MaxDepth
+    {
+        get => _maxDepth;
+        set
+        {
+            if (value == 0) _maxDepth = DefaultMaxDepth;
+            _maxDepth = value;
+        }
+    }
+
+    /// <summary>
+    /// The list of custom HTML Converters to use during serialization.
+    /// </summary>
+    public List<HtmlConverter> Converters { get; }
+
+    /// <summary>
+    /// CSS classes added to serialized HTML nodes.
+    /// </summary>
+    public CssClasses CssClasses { get; }
 }
 
 public class CssClasses
 {
-    internal const string DefaultNullCssClass = "null";
-    internal const string DefaultPropertyNameClass = "property-name";
-    internal const string DefaultPropertyValueClass = "property-value";
-    internal const string DefaultEmptyCollectionCssClass = "empty-collection";
-    internal const string DefaultCyclicReferenceCssClass = "cyclic-reference";
-    internal const string DefaultTableInfoHeaderCssClass = "table-info-header";
-    internal const string DefaultTableDataHeaderCssClass = "table-data-header";
+    public const string DefaultNullCssClass = "null";
+    public const string DefaultPropertyNameClass = "property-name";
+    public const string DefaultPropertyValueClass = "property-value";
+    public const string DefaultEmptyCollectionCssClass = "empty-collection";
+    public const string DefaultCyclicReferenceCssClass = "cyclic-reference";
+    public const string DefaultMaxDepthReachedCssClass = "max-depth-reached";
+    public const string DefaultTableInfoHeaderCssClass = "table-info-header";
+    public const string DefaultTableDataHeaderCssClass = "table-data-header";
 
     /// <summary>
-    /// The CSS class added to null values.
+    /// The CSS class added to null values. (Default: <see cref="DefaultNullCssClass"/>)
     /// </summary>
     public string Null { get; set; } = DefaultNullCssClass;
 
     /// <summary>
-    /// The CSS class added to property names.
+    /// The CSS class added to property names. (Default: <see cref="DefaultPropertyNameClass"/>)
     /// </summary>
     public string PropertyName { get; set; } = DefaultPropertyNameClass;
 
     /// <summary>
-    /// The CSS class added to property values.
+    /// The CSS class added to property values. (Default: <see cref="DefaultPropertyValueClass"/>)
     /// </summary>
     public string PropertyValue { get; set; } = DefaultPropertyValueClass;
 
     /// <summary>
-    /// The CSS class added to empty collections.
+    /// The CSS class added to empty collections. (Default: <see cref="DefaultEmptyCollectionCssClass"/>)
     /// </summary>
     public string EmptyCollection { get; set; } = DefaultEmptyCollectionCssClass;
 
     /// <summary>
-    /// The CSS class added to cyclic references.
+    /// The CSS class added to cyclic references. (Default: <see cref="DefaultCyclicReferenceCssClass"/>)
     /// </summary>
     public string CyclicReference { get; set; } = DefaultCyclicReferenceCssClass;
 
     /// <summary>
-    /// The CSS class added to a table's info header.
+    /// The CSS class added to max depth reached elements. (Default: <see cref="DefaultMaxDepthReachedCssClass"/>)
+    /// </summary>
+    public string MaxDepthReached { get; set; } = DefaultMaxDepthReachedCssClass;
+
+    /// <summary>
+    /// The CSS class added to a table's info header. (Default: <see cref="DefaultTableInfoHeaderCssClass"/>)
     /// </summary>
     public string TableInfoHeader { get; set; } = DefaultTableInfoHeaderCssClass;
 
     /// <summary>
-    /// The CSS class added to a table's data header.
+    /// The CSS class added to a table's data header. (Default: <see cref="DefaultTableDataHeaderCssClass"/>)
     /// </summary>
     public string TableDataHeader { get; set; } = DefaultTableDataHeaderCssClass;
 }

--- a/src/External/O2Html/O2Html.csproj
+++ b/src/External/O2Html/O2Html.csproj
@@ -4,6 +4,11 @@
         <TargetFrameworks>net6.0;netstandard2.0;netstandard2.1;net7.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <LangVersion>10</LangVersion>
+        <AssemblyVersion>1.0.0</AssemblyVersion>
     </PropertyGroup>
 
+    <ItemGroup>
+        <InternalsVisibleTo Include="$(AssemblyName).Tests" />
+    </ItemGroup>
+    
 </Project>

--- a/src/External/O2Html/O2Html.csproj
+++ b/src/External/O2Html/O2Html.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;netstandard2.0;netstandard2.1;net7.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <LangVersion>10</LangVersion>
     </PropertyGroup>

--- a/src/External/O2Html/SerializationScope.cs
+++ b/src/External/O2Html/SerializationScope.cs
@@ -10,13 +10,16 @@ public class SerializationScope
     public SerializationScope(int depth)
     {
         Depth = depth;
-        _serializedObjects  = new HashSet<object>();
+        _serializedObjects  = new HashSet<object>(Common.ReferenceEqualityComparer.Instance);
     }
 
-    public SerializationScope(int depth, SerializationScope parentScope) : this(depth)
+    public SerializationScope(int depth, SerializationScope parentScope)
     {
-        _serializedObjects  = new HashSet<object>(parentScope.SerializedObjects
-                                                  ?? throw new ArgumentNullException(nameof(parentScope)));
+        Depth = depth;
+        _serializedObjects  = new HashSet<object>(
+            parentScope.SerializedObjects ?? throw new ArgumentNullException(nameof(parentScope)),
+            Common.ReferenceEqualityComparer.Instance
+        );
     }
 
     public int Depth { get; }

--- a/src/External/O2Html/SerializationScope.cs
+++ b/src/External/O2Html/SerializationScope.cs
@@ -7,16 +7,19 @@ public class SerializationScope
 {
     private readonly HashSet<object> _serializedObjects;
 
-    public SerializationScope()
+    public SerializationScope(int depth)
     {
+        Depth = depth;
         _serializedObjects  = new HashSet<object>();
     }
 
-    public SerializationScope(SerializationScope parentScope)
+    public SerializationScope(int depth, SerializationScope parentScope) : this(depth)
     {
         _serializedObjects  = new HashSet<object>(parentScope.SerializedObjects
                                                   ?? throw new ArgumentNullException(nameof(parentScope)));
     }
+
+    public int Depth { get; }
 
     public IReadOnlyCollection<object> SerializedObjects => _serializedObjects;
 

--- a/src/External/O2Html/Utilities.cs
+++ b/src/External/O2Html/Utilities.cs
@@ -13,7 +13,7 @@ internal static class Utilities
     /// </summary>
     /// <param name="str">The string to escape.</param>
     /// <returns>The escaped string.</returns>
-#if NET6_0_OR_GREATER
+#if NETCOREAPP3_0_OR_GREATER
     [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNull("str")]
 #endif
     public static string? EscapeStringForHtml(string? str)

--- a/src/Infrastructure/ScriptRuntimes/NetPad.ExternalProcessScriptRuntime/DefaultExternalProcessScriptRuntimeFactory.cs
+++ b/src/Infrastructure/ScriptRuntimes/NetPad.ExternalProcessScriptRuntime/DefaultExternalProcessScriptRuntimeFactory.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NetPad.Compilation;
+using NetPad.Configuration;
 using NetPad.DotNet;
 using NetPad.IO;
 using NetPad.Packages;
@@ -25,6 +26,7 @@ public class DefaultExternalProcessScriptRuntimeFactory : IScriptRuntimeFactory
             _serviceProvider.GetRequiredService<ICodeCompiler>(),
             _serviceProvider.GetRequiredService<IPackageProvider>(),
             _serviceProvider.GetRequiredService<IDotNetInfo>(),
+            _serviceProvider.GetRequiredService<Settings>(),
             _serviceProvider.GetRequiredService<ILogger<ExternalProcessScriptRuntime>>()
         );
 

--- a/src/Infrastructure/ScriptRuntimes/NetPad.ExternalProcessScriptRuntime/ExternalProcessScriptRuntime.cs
+++ b/src/Infrastructure/ScriptRuntimes/NetPad.ExternalProcessScriptRuntime/ExternalProcessScriptRuntime.cs
@@ -43,6 +43,7 @@ public sealed class ExternalProcessScriptRuntime : IScriptRuntime<IScriptOutputA
     private readonly ICodeCompiler _codeCompiler;
     private readonly IPackageProvider _packageProvider;
     private readonly IDotNetInfo _dotNetInfo;
+    private readonly Settings _settings;
     private readonly ILogger<ExternalProcessScriptRuntime> _logger;
     private readonly HashSet<IInputReader<string>> _externalInputReaders;
     private readonly MainScriptOutputAdapter _outputAdapter;
@@ -58,6 +59,7 @@ public sealed class ExternalProcessScriptRuntime : IScriptRuntime<IScriptOutputA
         ICodeCompiler codeCompiler,
         IPackageProvider packageProvider,
         IDotNetInfo dotNetInfo,
+        Settings settings,
         ILogger<ExternalProcessScriptRuntime> logger)
     {
         _script = script;
@@ -65,6 +67,7 @@ public sealed class ExternalProcessScriptRuntime : IScriptRuntime<IScriptOutputA
         _codeCompiler = codeCompiler;
         _packageProvider = packageProvider;
         _dotNetInfo = dotNetInfo;
+        _settings = settings;
         _logger = logger;
         _externalInputReaders = new HashSet<IInputReader<string>>();
         _externalOutputAdapters = new HashSet<IScriptOutputAdapter<ScriptOutput, ScriptOutput>>();
@@ -243,6 +246,15 @@ public sealed class ExternalProcessScriptRuntime : IScriptRuntime<IScriptOutputA
             Path.Combine(processRootFolder.FullName, $"{fileSafeScriptName}.runtimeconfig.json"),
             GenerateRuntimeConfigFileContents(runDependencies)
         );
+
+        await File.WriteAllTextAsync(
+            Path.Combine(processRootFolder.FullName, "scriptconfig.json"),
+            $@"{{
+    ""output"": {{
+        ""maxDepth"": {_settings.Results.MaxSerializationDepth},
+        ""maxCollectionSerializeLength"": {_settings.Results.MaxCollectionSerializeLength}
+    }}
+}}");
 
         foreach (var referenceAssemblyImage in runDependencies.AssemblyImageDependencies)
         {

--- a/src/Infrastructure/ScriptRuntimes/NetPad.ExternalProcessScriptRuntime/RawOutputHandler.cs
+++ b/src/Infrastructure/ScriptRuntimes/NetPad.ExternalProcessScriptRuntime/RawOutputHandler.cs
@@ -1,0 +1,79 @@
+using System.Collections.Concurrent;
+using NetPad.IO;
+using NetPad.Utilities;
+
+namespace NetPad.Runtimes;
+
+/// <summary>
+/// Handles unstructured raw process output. Used to buffer output and give it order. Usually raw process output
+/// is not user-designated output and can be unpredictable (ex. stackoverflow output can be thousands of lines in rapid succession).
+/// </summary>
+internal class RawOutputHandler
+{
+    private uint _rawResultOutputOrder;
+    private uint _rawResultOutputPushOrder;
+    private uint _rawErrorOutputOrder;
+    private uint _rawErrorOutputPushOrder;
+    private readonly ConcurrentQueue<(uint order, string output)> _rawResultOutput;
+    private readonly ConcurrentQueue<(uint order, string output)> _rawErrorOutput;
+    private readonly Action PushResultOutput;
+    private readonly Action PushErrorOutput;
+
+    public RawOutputHandler(IScriptOutputAdapter scriptOutputAdapter)
+    {
+        _rawResultOutput = new();
+        _rawErrorOutput = new();
+
+        PushResultOutput = new Func<Task>(async () =>
+        {
+            var list = new List<(uint order, string output)>();
+
+            while (_rawResultOutput.TryDequeue(out var output))
+                list.Add(output);
+
+            if (!list.Any()) return;
+
+            string finalOutput = list.OrderBy(x => x.order).Select(x => x.output).JoinToString("\n") + "\n";
+
+            await scriptOutputAdapter.ResultsChannel.WriteAsync(new RawScriptOutput(
+                Interlocked.Increment(ref _rawResultOutputPushOrder) - 1,
+                finalOutput));
+        }).DebounceAsync();
+
+        PushErrorOutput = new Func<Task>(async () =>
+        {
+            var list = new List<(uint order, string output)>();
+
+            while (_rawErrorOutput.TryDequeue(out var output))
+                list.Add(output);
+
+            if (!list.Any()) return;
+
+            string finalOutput = list.OrderBy(x => x.order).Select(x => x.output).JoinToString("\n") + "\n";
+
+            await scriptOutputAdapter.ResultsChannel.WriteAsync(new ErrorScriptOutput(
+                Interlocked.Increment(ref _rawErrorOutputPushOrder) - 1,
+                finalOutput));
+        }).DebounceAsync();
+    }
+
+    public void Reset()
+    {
+        _rawResultOutputOrder = 0;
+        _rawResultOutputPushOrder = 0;
+        _rawErrorOutputOrder = 0;
+        _rawErrorOutputPushOrder = 0;
+    }
+
+    public void RawResultOutputReceived(string output)
+    {
+        _rawResultOutput.Enqueue((Interlocked.Increment(ref _rawResultOutputOrder) - 1, output));
+        PushResultOutput();
+    }
+
+    public void RawErrorOutputReceived(string output)
+    {
+        _rawErrorOutput.Enqueue((Interlocked.Increment(ref _rawErrorOutputOrder) - 1, output));
+        PushErrorOutput();
+    }
+}

--- a/src/Infrastructure/ScriptRuntimes/NetPad.ExternalProcessScriptRuntime/ScriptRuntimeServices.cs
+++ b/src/Infrastructure/ScriptRuntimes/NetPad.ExternalProcessScriptRuntime/ScriptRuntimeServices.cs
@@ -58,7 +58,7 @@ public static class Extensions
     /// <summary>
     /// Dumps this object to the results view.
     /// </summary>
-    /// <param name="o">The object being dumped.</param>
+    /// <param name="o">The object to dump.</param>
     /// <param name="title">An optional title for the result.</param>
     /// <returns>The object being dumped.</returns>
     [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNull("o")]
@@ -75,6 +75,30 @@ public static class Extensions
             ScriptRuntimeServices.ResultWrite("\n");
 
         return o;
+    }
+
+    /// <summary>
+    /// Dumps this <see cref="Span{T}"/> to the results view.
+    /// </summary>
+    /// <param name="span">The <see cref="Span{T}"/> to dump.</param>
+    /// <param name="title">An optional title for the result.</param>
+    /// <returns>The <see cref="Span{T}"/> being dumped.</returns>
+    public static Span<T> Dump<T>(this Span<T> span, string? title = null)
+    {
+        ScriptRuntimeServices.ResultWrite(span.ToArray(), title);
+        return span;
+    }
+
+    /// <summary>
+    /// Dumps this <see cref="ReadOnlySpan{T}"/> to the results view.
+    /// </summary>
+    /// <param name="span">The <see cref="ReadOnlySpan{T}"/> to dump.</param>
+    /// <param name="title">An optional title for the result.</param>
+    /// <returns>The <see cref="ReadOnlySpan{T}"/> being dumped.</returns>
+    public static ReadOnlySpan<T> Dump<T>(this ReadOnlySpan<T> span, string? title = null)
+    {
+        ScriptRuntimeServices.ResultWrite(span.ToArray(), title);
+        return span;
     }
 }
 


### PR DESCRIPTION
closes #58 

Adds multiple improvements to O2HTML serialization library including:
* Max serialization depth
* Special serialization of:
   * `FileSystemInfo` types (`FileInfo` & `DirectoryInfo`)
   * `Memory<T>` and `ReadOnlyMemory<T>`
* Better cyclic reference detection
* Performance optimizations
* More unit tests

Other changes:
* `.Dump()` method now also supports dumping `Span<T>` and `ReadOnlySpan<T>`, however it cannot serialize these types if they are not the root object being dumped. It such a case, it will serialize basic info about span.
* Adds user setting to configure new serialization max depth
* Adds user setting to configure max number of collection items to serialize, was previously hard-coded to 1000