### PR TITLE
Fixed DbSet property naming

### DIFF
--- a/src/Infrastructure/NetPad.Infrastructure/Data/EntityFrameworkCore/EntityFrameworkResourcesGenerator.cs
+++ b/src/Infrastructure/NetPad.Infrastructure/Data/EntityFrameworkCore/EntityFrameworkResourcesGenerator.cs
@@ -237,7 +237,7 @@ public class EntityFrameworkResourcesGenerator : IDataConnectionResourcesGenerat
     public static Microsoft.EntityFrameworkCore.DbSet<{entityType}> {propertyName} => DataContext.{dbContextPropertyName};");
 
             // Rename property on DbContext
-            dbContextCodeLines[iLine] = line.Replace(propertyName, dbContextPropertyName);
+            dbContextCodeLines[iLine] = line.Replace($" {propertyName} ", $" {dbContextPropertyName} ");
         }
 
         // Replace the DbContext code since we modified it above when renaming properties


### PR DESCRIPTION
close #70

sometimes the DbSet name is the same as the property name, which ends up altering the DbSet name by adding the suffix HIDDEN

```c#
public virtual DbSet<Employee> Employees_HIDDEN { get; set; } = null!;
public virtual DbSet<EmployeeDevice> EmployeeDevices_HIDDEN { get; set; } = null!;
 public virtual DbSet<Equipment_HIDDEN> Equipment_HIDDEN { get; set; } = null!;
```