### PR TITLE
Fixes bug where SqlClient was not included in macOS builds

### DIFF
--- a/src/Apps/NetPad.Apps.App/NetPad.Apps.App.csproj
+++ b/src/Apps/NetPad.Apps.App/NetPad.Apps.App.csproj
@@ -46,7 +46,7 @@
             <CopyToPublishDirectory>Never</CopyToPublishDirectory>
         </Content>
     </ItemGroup>
-    <ItemGroup Condition="'$(RuntimeIdentifier)' == 'linux-x64' Or '$(RuntimeIdentifier)' == ''">
+    <ItemGroup Condition="'$(RuntimeIdentifier)' != 'win-x64' Or '$(RuntimeIdentifier)' == ''">
         <None Update="Assets\Assemblies\Microsoft.Data.SqlClient\2.1.4\unix\Microsoft.Data.SqlClient.dll">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>


### PR DESCRIPTION
closes #69 

SqlClient assemblies were not included in macOS builds due to a faulty .csproj configuration.