### PR TITLE
Contextual tab options: Rename & Duplicate

### DIFF
--- a/src/Apps/NetPad.Apps.App/App/src/core/@domain/api.ts
+++ b/src/Apps/NetPad.Apps.App/App/src/core/@domain/api.ts
@@ -101,7 +101,7 @@ export class AppApiClient extends ApiClientBase implements IAppApiClient {
             let result200: any = null;
             let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
                 result200 = resultData200 !== undefined ? resultData200 : <any>null;
-    
+
             return result200;
             });
         } else if (status !== 200 && status !== 204) {
@@ -702,7 +702,7 @@ export class DataConnectionsApiClient extends ApiClientBase implements IDataConn
             let result200: any = null;
             let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
                 result200 = resultData200 !== undefined ? resultData200 : <any>null;
-    
+
             return result200;
             });
         } else if (status !== 200 && status !== 204) {
@@ -781,7 +781,7 @@ export class DataConnectionsApiClient extends ApiClientBase implements IDataConn
             let result200: any = null;
             let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
                 result200 = resultData200 !== undefined ? resultData200 : <any>null;
-    
+
             return result200;
             });
         } else if (status !== 200 && status !== 204) {
@@ -1207,6 +1207,10 @@ export interface IScriptsApiClient {
 
     save(id: string, signal?: AbortSignal | undefined): Promise<void>;
 
+    rename(id: string, signal?: AbortSignal | undefined): Promise<void>;
+
+    duplicate(id: string, signal?: AbortSignal | undefined): Promise<void>;
+
     run(id: string, dto: RunOptionsDto, signal?: AbortSignal | undefined): Promise<void>;
 
     stop(id: string, signal?: AbortSignal | undefined): Promise<void>;
@@ -1338,11 +1342,79 @@ export class ScriptsApiClient extends ApiClientBase implements IScriptsApiClient
         let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
         if (status === 200) {
             return response.text().then((_responseText) => {
-            return;
+                return;
             });
         } else if (status !== 200 && status !== 204) {
             return response.text().then((_responseText) => {
-            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+                return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<void>(<any>null);
+    }
+
+    rename(id: string, signal?: AbortSignal | undefined): Promise<void> {
+        let url_ = this.baseUrl + "/scripts/{id}/rename";
+        if (id === undefined || id === null)
+            throw new Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_ = <RequestInit>{
+            method: "PATCH",
+            signal,
+            headers: {
+            }
+        };
+
+        return this.makeFetchCall(() => this.http.fetch(url_, options_)).then((_response: Response) => {
+            return this.processRename(_response);
+        });
+    }
+
+    protected processRename(response: Response): Promise<void> {
+        const status = response.status;
+        let _headers: any = { }; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+                return;
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+                return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<void>(<any>null);
+    }
+
+    duplicate(id: string, signal?: AbortSignal | undefined): Promise<void> {
+        let url_ = this.baseUrl + "/scripts/{id}/duplicate";
+        if (id === undefined || id === null)
+            throw new Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_ = <RequestInit>{
+            method: "PATCH",
+            signal,
+            headers: {
+            }
+        };
+
+        return this.makeFetchCall(() => this.http.fetch(url_, options_)).then((_response: Response) => {
+            return this.processDuplicate(_response);
+        });
+    }
+
+    protected processDuplicate(response: Response): Promise<void> {
+        const status = response.status;
+        let _headers: any = { }; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+                return;
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+                return throwException("An unexpected server error occurred.", status, _responseText, _headers);
             });
         }
         return Promise.resolve<void>(<any>null);
@@ -1895,7 +1967,7 @@ export class SessionApiClient extends ApiClientBase implements ISessionApiClient
             let result200: any = null;
             let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
                 result200 = resultData200 !== undefined ? resultData200 : <any>null;
-    
+
             return result200;
             });
         } else if (status !== 200 && status !== 204) {

--- a/src/Apps/NetPad.Apps.App/App/src/styles/_icons.scss
+++ b/src/Apps/NetPad.Apps.App/App/src/styles/_icons.scss
@@ -56,6 +56,16 @@ button > .icon-base {
     @extend .fa-floppy-disk;
 }
 
+.duplicate-icon {
+    @extend %icon-base;
+    @extend .fa-clone;
+}
+
+.rename-icon {
+    @extend %icon-base;
+    @extend .fa-pen-to-square;
+}
+
 .delete-icon {
     @extend %icon-base;
     @extend .fa-trash;

--- a/src/Apps/NetPad.Apps.App/App/src/windows/main/work-area/tab-bar/tab-bar.ts
+++ b/src/Apps/NetPad.Apps.App/App/src/windows/main/work-area/tab-bar/tab-bar.ts
@@ -65,6 +65,16 @@ export class TabBar extends ViewModelBase {
                 onSelected: async (clickTarget) => await (this.getViewable(clickTarget) as ViewableAppScriptDocument).stop()
             },
             {
+                icon: "rename-icon",
+                text: "Rename",
+                onSelected: async (clickTarget) => await this.getViewable(clickTarget).rename()
+            },
+            {
+                icon: "duplicate-icon",
+                text: "Duplicate",
+                onSelected: async (clickTarget) => await this.getViewable(clickTarget).duplicate()
+            },
+            {
                 icon: "save-icon",
                 text: "Save",
                 shortcut: this.shortcutManager.getShortcutByName("Save"),

--- a/src/Apps/NetPad.Apps.App/App/src/windows/main/work-area/viewers/viewable-object.ts
+++ b/src/Apps/NetPad.Apps.App/App/src/windows/main/work-area/viewers/viewable-object.ts
@@ -11,6 +11,8 @@ export interface IViewableObjectCommands
     open: (viewerHost: ViewerHost) => Promise<void>;
     close: (viewerHost: ViewerHost) => Promise<void>;
     activate: (viewerHost: ViewerHost) => Promise<void>;
+    rename: () => Promise<void>;
+    duplicate: () => Promise<void>;
     save: () => Promise<void>;
     openContainingFolder: () => Promise<void>;
 }
@@ -42,6 +44,14 @@ export abstract class ViewableObject extends WithDisposables {
 
     public activate(viewerHost: ViewerHost): Promise<void> {
         return this.commands.activate(viewerHost);
+    }
+
+    public rename(): Promise<void> {
+        return this.commands.rename();
+    }
+
+    public duplicate(): Promise<void> {
+        return this.commands.duplicate();
     }
 
     public save(): Promise<void> {

--- a/src/Apps/NetPad.Apps.App/App/src/windows/main/work-area/work-area.ts
+++ b/src/Apps/NetPad.Apps.App/App/src/windows/main/work-area/work-area.ts
@@ -127,6 +127,8 @@ export class WorkArea extends ViewModelBase {
             },
             activate: async (viewerHost) => await this.session.activate(environment.script.id),
             save: async () => await this.scriptService.save(environment.script.id),
+            rename: async () => await this.scriptService.rename(environment.script.id),
+            duplicate: async () => await this.scriptService.duplicate(environment.script.id),
             openContainingFolder: async () => environment.script.path
                 ? await this.appService.openFolderContainingScript(environment.script.path)
                 : Promise.reject("Script has not been saved yet"),

--- a/src/Apps/NetPad.Apps.App/Controllers/ScriptsController.cs
+++ b/src/Apps/NetPad.Apps.App/Controllers/ScriptsController.cs
@@ -55,6 +55,21 @@ public class ScriptsController : Controller
         }
     }
 
+    [HttpPatch("{id:guid}/rename")]
+    public async Task Rename(Guid id)
+    {
+        var environment = await GetScriptEnvironmentAsync(id);
+        await _mediator.Send(new RenameScriptCommand(environment.Script));
+    }
+
+    [HttpPatch("{id:guid}/duplicate")]
+    public async Task Duplicate(Guid id)
+    {
+        var environment = await GetScriptEnvironmentAsync(id);
+        var script = await _mediator.Send(new DuplicateScriptCommand(environment.Script));
+        await _mediator.Send(new OpenScriptCommand(script));
+    }
+
     [HttpPatch("{id:guid}/save")]
     public async Task Save(Guid id)
     {

--- a/src/Core/NetPad.Application/CQs/DuplicateScriptCommand.cs
+++ b/src/Core/NetPad.Application/CQs/DuplicateScriptCommand.cs
@@ -45,13 +45,8 @@ public class DuplicateScriptCommand : Command<Script>
             await _eventBus.PublishAsync(new ScriptCreatedEvent(script));
 
             script.SetDataConnection(request.Script.DataConnection);
-            script.SetConfig(request.Script.Config);
+            script.UpdateConfig(request.Script.Config);
             script.UpdateCode(request.Script.Code);
-
-            if (!request.Script.IsNew)
-            {
-                script.SetPath(Path.Combine(request.Script.DirectoryPath!, script.Name));
-            }
 
             return script;
         }

--- a/src/Core/NetPad.Application/CQs/DuplicateScriptCommand.cs
+++ b/src/Core/NetPad.Application/CQs/DuplicateScriptCommand.cs
@@ -1,0 +1,59 @@
+using MediatR;
+using NetPad.Events;
+using NetPad.IO;
+using NetPad.Scripts;
+using NetPad.UiInterop;
+
+namespace NetPad.CQs;
+
+/// <summary>
+/// Duplicates a script.
+/// </summary>
+public class DuplicateScriptCommand : Command<Script>
+{
+    public Script Script { get; }
+
+    public DuplicateScriptCommand(Script script)
+    {
+        Script = script;
+    }
+
+    public class Handler : IRequestHandler<DuplicateScriptCommand, Script>
+    {
+        private readonly IScriptRepository _scriptRepository;
+        private readonly IAutoSaveScriptRepository _autoSaveScriptRepository;
+        private readonly IScriptNameGenerator _scriptNameGenerator;
+        private readonly IEventBus _eventBus;
+
+        public Handler(
+            IScriptRepository scriptRepository,
+            IScriptNameGenerator scriptNameGenerator,
+            IAutoSaveScriptRepository autoSaveScriptRepository,
+            IEventBus eventBus
+        )
+        {
+            _autoSaveScriptRepository = autoSaveScriptRepository;
+            _scriptRepository = scriptRepository;
+            _scriptNameGenerator = scriptNameGenerator;
+            _eventBus = eventBus;
+        }
+
+        public async Task<Script> Handle(DuplicateScriptCommand request, CancellationToken cancellationToken)
+        {
+            var name = _scriptNameGenerator.Generate(request.Script.Name);
+            var script = await _scriptRepository.CreateAsync(name);
+            await _eventBus.PublishAsync(new ScriptCreatedEvent(script));
+
+            script.SetDataConnection(request.Script.DataConnection);
+            script.SetConfig(request.Script.Config);
+            script.UpdateCode(request.Script.Code);
+
+            if (!request.Script.IsNew)
+            {
+                script.SetPath(Path.Combine(request.Script.DirectoryPath!, script.Name));
+            }
+
+            return script;
+        }
+    }
+}

--- a/src/Core/NetPad.Application/CQs/RenameScriptCommand.cs
+++ b/src/Core/NetPad.Application/CQs/RenameScriptCommand.cs
@@ -1,0 +1,62 @@
+using MediatR;
+using NetPad.Events;
+using NetPad.Scripts;
+using NetPad.UiInterop;
+
+namespace NetPad.CQs;
+
+/// <summary>
+/// Renames a script. Returns true if script was renamed, false otherwise.
+/// </summary>
+public class RenameScriptCommand : Command<bool>
+{
+    public Script Script { get; }
+
+    public RenameScriptCommand(Script script)
+    {
+        Script = script;
+    }
+
+    public class Handler : IRequestHandler<RenameScriptCommand, bool>
+    {
+        private readonly IUiDialogService _uiDialogService;
+        private readonly IScriptRepository _scriptRepository;
+        private readonly IAutoSaveScriptRepository _autoSaveScriptRepository;
+        private readonly IEventBus _eventBus;
+
+        public Handler(
+            IUiDialogService uiDialogService,
+            IScriptRepository scriptRepository,
+            IAutoSaveScriptRepository autoSaveScriptRepository,
+            IEventBus eventBus
+        )
+        {
+            _uiDialogService = uiDialogService;
+            _scriptRepository = scriptRepository;
+            _autoSaveScriptRepository = autoSaveScriptRepository;
+            _eventBus = eventBus;
+        }
+
+        public async Task<bool> Handle(RenameScriptCommand request, CancellationToken cancellationToken)
+        {
+            var script = request.Script;
+
+            var path = await _uiDialogService.AskUserForSaveLocation(script);
+
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return false;
+            }
+
+            _scriptRepository.Rename(script, path);
+
+            await _scriptRepository.SaveAsync(script);
+
+            await _autoSaveScriptRepository.DeleteAsync(script);
+
+            await _eventBus.PublishAsync(new ScriptSavedEvent(script));
+
+            return true;
+        }
+    }
+}

--- a/src/Core/NetPad.Application/NetPad.Application.csproj
+++ b/src/Core/NetPad.Application/NetPad.Application.csproj
@@ -8,13 +8,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\NetPad.Domain\NetPad.Domain.csproj"/>
+        <ProjectReference Include="..\NetPad.Domain\NetPad.Domain.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="MediatR" Version="10.0.1"/>
-        <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0"/>
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0"/>
+        <PackageReference Include="MediatR" Version="10.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
     </ItemGroup>
 
 </Project>

--- a/src/Core/NetPad.Application/Scripts/DefaultScriptNameGenerator.cs
+++ b/src/Core/NetPad.Application/Scripts/DefaultScriptNameGenerator.cs
@@ -11,10 +11,8 @@ public class DefaultScriptNameGenerator : IScriptNameGenerator
         _session = session;
     }
 
-    public string Generate()
+    public string Generate(string baseName = "Script")
     {
-        const string baseName = "Script";
-
         var lastNumber = _session.Environments
             .Select(e =>
             {

--- a/src/Core/NetPad.Domain/Scripts/IScriptNameGenerator.cs
+++ b/src/Core/NetPad.Domain/Scripts/IScriptNameGenerator.cs
@@ -2,5 +2,5 @@ namespace NetPad.Scripts;
 
 public interface IScriptNameGenerator
 {
-    string Generate();
+    string Generate(string baseName = "Script");
 }

--- a/src/Core/NetPad.Domain/Scripts/IScriptRepository.cs
+++ b/src/Core/NetPad.Domain/Scripts/IScriptRepository.cs
@@ -11,5 +11,6 @@ public interface IScriptRepository
     Task<Script> GetAsync(string path);
     Task<Script?> GetAsync(Guid scriptId);
     Task<Script> SaveAsync(Script script);
+    void Rename(Script script, string newName);
     Task DeleteAsync(Script script);
 }

--- a/src/Core/NetPad.Domain/Scripts/Script.cs
+++ b/src/Core/NetPad.Domain/Scripts/Script.cs
@@ -57,7 +57,7 @@ public class Script : INotifyOnPropertyChanged
     }
 
 
-    public ScriptConfig Config { get; }
+    public ScriptConfig Config { get; private set; }
 
     public DataConnection? DataConnection
     {
@@ -80,6 +80,11 @@ public class Script : INotifyOnPropertyChanged
     public string? DirectoryPath => Path == null ? null : System.IO.Path.GetDirectoryName(Path);
 
     public bool IsNew => Path == null;
+
+    public void SetConfig(ScriptConfig config)
+    {
+        Config = config;
+    }
 
     public void SetPath(string path)
     {

--- a/src/Core/NetPad.Domain/Scripts/Script.cs
+++ b/src/Core/NetPad.Domain/Scripts/Script.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using NetPad.Common;
@@ -57,7 +58,7 @@ public class Script : INotifyOnPropertyChanged
     }
 
 
-    public ScriptConfig Config { get; private set; }
+    public ScriptConfig Config { get; }
 
     public DataConnection? DataConnection
     {
@@ -81,9 +82,12 @@ public class Script : INotifyOnPropertyChanged
 
     public bool IsNew => Path == null;
 
-    public void SetConfig(ScriptConfig config)
+    public void UpdateConfig(ScriptConfig config)
     {
-        Config = config;
+        Config.SetKind(config.Kind);
+        Config.SetTargetFrameworkVersion(config.TargetFrameworkVersion);
+        Config.SetReferences(config.References);
+        Config.SetNamespaces(config.Namespaces);
     }
 
     public void SetPath(string path)

--- a/src/Infrastructure/NetPad.Infrastructure/Scripts/FileSystemScriptRepository.cs
+++ b/src/Infrastructure/NetPad.Infrastructure/Scripts/FileSystemScriptRepository.cs
@@ -144,6 +144,27 @@ public class FileSystemScriptRepository : IScriptRepository
         return script;
     }
 
+    public void Rename(Script script, string newPath)
+    {
+        if (newPath == null)
+            throw new InvalidOperationException($"{nameof(script.Path)} is not set. Cannot save script.");
+
+        // Basic protection against malicious calls
+        if (!newPath.EndsWith(Script.STANDARD_EXTENSION, StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException($"Script file must end with {Script.STANDARD_EXTENSION}");
+
+        if (!script.IsNew)
+        {
+            if (script.Path == null)
+                throw new InvalidOperationException($"{nameof(script.Path)} is not set. Cannot save script.");
+
+            // overwrite: true since the OS will ask the user to confirm the overwrite
+            File.Move(script.Path, newPath, overwrite: true);
+        }
+
+        script.SetPath(newPath);
+    }
+
     public Task DeleteAsync(Script script)
     {
         if (script.Path == null)


### PR DESCRIPTION
I was tired of copying the original script file and manually changing the uuid inside the file to create a new file with the same config and namespaces so I added these contextual tab options:
- rename
- duplicate

they don't have shortcuts at the moment.

<img width="1086" alt="image" src="https://github.com/tareqimbasher/NetPad/assets/23088305/fc90678b-84a1-4666-8263-63a36c949ddf">
