### PR TITLE
Fix not finding .NET SDK when running EF Core tool

### DIFF
--- a/src/Core/NetPad.Domain/DotNet/DotNetInfo.cs
+++ b/src/Core/NetPad.Domain/DotNet/DotNetInfo.cs
@@ -86,6 +86,11 @@ public class DotNetInfo : IDotNetInfo
                 }
             }
 
+            if (rootDirPath != null)
+            {
+                Environment.SetEnvironmentVariable("DOTNET_ROOT", rootDirPath);
+            }
+
             _dotNetRootDirPath = rootDirPath;
         }
 
@@ -295,7 +300,7 @@ public class DotNetInfo : IDotNetInfo
                     WindowStyle = ProcessWindowStyle.Hidden,
                     FileName = exeName,
                     Arguments = "--version"
-                });
+                }.CopyCurrentEnvironmentVariables());
 
                 path = process?.MainModule?.FileName;
 
@@ -310,7 +315,7 @@ public class DotNetInfo : IDotNetInfo
                 // if it failed, it wasn't found
             }
 
-            if (string.IsNullOrEmpty(path))
+            if (string.IsNullOrWhiteSpace(path))
             {
                 // Try getting path from global tool install path
                 var globalToolInstallPath = Path.Combine(
@@ -343,7 +348,7 @@ public class DotNetInfo : IDotNetInfo
             FileName = dotNetEfToolExePath,
             Arguments = "--version",
             RedirectStandardOutput = true
-        });
+        }.CopyCurrentEnvironmentVariables());
 
         if (p == null)
             throw new Exception("Could not start EF dotnet tool executable");
@@ -394,7 +399,7 @@ public class DotNetInfo : IDotNetInfo
                 WindowStyle = ProcessWindowStyle.Hidden,
                 FileName = exeName,
                 Arguments = "--version"
-            });
+            }.CopyCurrentEnvironmentVariables());
 
             var path = process?.MainModule?.FileName;
 
@@ -429,11 +434,13 @@ public class DotNetInfo : IDotNetInfo
         }
         else
         {
-            possibleDirectories.Add(@"/usr/local/share/dotnet"); // default for macOS
-            possibleDirectories.Add(@"/usr/share/dotnet");
-            possibleDirectories.Add(@"/usr/lib/dotnet");
-            possibleDirectories.Add(@"/opt/dotnet");
+            possibleDirectories.Add("/usr/local/share/dotnet"); // default for macOS
+            possibleDirectories.Add("/usr/share/dotnet");
+            possibleDirectories.Add("/usr/lib/dotnet");
+            possibleDirectories.Add("/opt/dotnet");
         }
+
+        possibleDirectories.Add(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".dotnet"));
 
         foreach (var directory in possibleDirectories)
         {

--- a/src/Core/NetPad.Domain/IO/ProcessHandler.cs
+++ b/src/Core/NetPad.Domain/IO/ProcessHandler.cs
@@ -162,12 +162,7 @@ public sealed class ProcessHandler : IDisposable
             if (!string.IsNullOrWhiteSpace(_args))
                 _processStartInfo.Arguments = _args;
 
-            // Copy current env variables to new process
-            var envVars = Environment.GetEnvironmentVariables();
-            foreach (string key in envVars.Keys)
-            {
-                _processStartInfo.EnvironmentVariables[key] = envVars[key]?.ToString();
-            }
+            _processStartInfo.CopyCurrentEnvironmentVariables();
         }
 
         if (_process == null)

--- a/src/Core/NetPad.Domain/Utilities/ProcessUtil.cs
+++ b/src/Core/NetPad.Domain/Utilities/ProcessUtil.cs
@@ -31,4 +31,18 @@ public static class ProcessUtil
             UseShellExecute = true
         });
     }
+
+    public static ProcessStartInfo CopyCurrentEnvironmentVariables(this ProcessStartInfo processStartInfo, bool overwrite = true)
+    {
+        var envVars = Environment.GetEnvironmentVariables();
+
+        foreach (string key in envVars.Keys)
+        {
+            if (!overwrite && processStartInfo.EnvironmentVariables.ContainsKey(key)) continue;
+
+            processStartInfo.EnvironmentVariables[key] = envVars[key]?.ToString();
+        }
+
+        return processStartInfo;
+    }
 }

--- a/src/Infrastructure/NetPad.Infrastructure/Data/EntityFrameworkCore/Scaffolding/EntityFrameworkDatabaseScaffolder.cs
+++ b/src/Infrastructure/NetPad.Infrastructure/Data/EntityFrameworkCore/Scaffolding/EntityFrameworkDatabaseScaffolder.cs
@@ -121,9 +121,10 @@ class Program
 
         // Add dotnet directory to the PATH because when dotnet-ef process starts, if dotnet is not in PATH
         // it will fail as dotnet-ef depends on dotnet
-        var dotnetExeDir = Path.GetDirectoryName(_dotNetInfo.LocateDotNetExecutableOrThrow());
+        var dotnetExeDir = _dotNetInfo.LocateDotNetRootDirectory();
         var pathVariableVal = startInfo.EnvironmentVariables["PATH"]?.TrimEnd(':');
         startInfo.EnvironmentVariables["PATH"] = string.IsNullOrWhiteSpace(pathVariableVal) ? dotnetExeDir : $"{pathVariableVal}:{dotnetExeDir}";
+        startInfo.EnvironmentVariables["DOTNET_ROOT"] = dotnetExeDir;
 
         var process = Process.Start(startInfo);
 


### PR DESCRIPTION
Also adds ~/.dotnet as a common .NET SDK install directory