### PR TITLE
#157 Use a fixed name for compiled script assemblies

### DIFF
--- a/src/Apps/NetPad.Apps.App/BackgroundServices/DebugAssemblyUnloadBackgroundService.cs
+++ b/src/Apps/NetPad.Apps.App/BackgroundServices/DebugAssemblyUnloadBackgroundService.cs
@@ -8,7 +8,7 @@ namespace NetPad.BackgroundServices;
 
 /// <summary>
 /// Periodically outputs the compiled script assemblies loaded by the program into memory. This is
-/// mainly used to debug assembly unloading after script execution.
+/// mainly used to debug assembly unloading after script execution (when using InMemoryScriptRuntime only).
 /// </summary>
 public class DebugAssemblyUnloadBackgroundService : BackgroundService
 {
@@ -26,7 +26,7 @@ public class DebugAssemblyUnloadBackgroundService : BackgroundService
 
                 int count = 0;
                 var names = AppDomain.CurrentDomain.GetAssemblies().Select(a => a.FullName)
-                    .Where(n => n?.Contains("NetPad_CompiledAssembly") == true)
+                    .Where(n => n?.Contains("NetPadScript") == true)
                     .Select(s => $"{++count}. {s?.Split(',')[0]}");
 
                 _logger.LogDebug("Loaded NetPad script assemblies (count: {Count}):\n{Assemblies}",

--- a/src/Core/NetPad.Compilation/CSharp/CSharpCodeCompiler.cs
+++ b/src/Core/NetPad.Compilation/CSharp/CSharpCodeCompiler.cs
@@ -23,16 +23,14 @@ public class CSharpCodeCompiler : ICodeCompiler
 
     public CompilationResult Compile(CompilationInput input)
     {
-        string assemblyName = "NetPad_CompiledAssembly";
+        string assemblyName = "NetPadScript";
 
         if (input.OutputAssemblyNameTag != null)
         {
             assemblyName += $"_{input.OutputAssemblyNameTag}";
         }
 
-        assemblyName += Guid.NewGuid().ToString();
-
-        string assemblyFileName = assemblyName + GetCompiledFileExtension(input.OutputKind);
+        string assemblyFileName = $"{assemblyName}{GetCompiledFileExtension(input.OutputKind)}";
 
         var compilation = CreateCompilation(input, assemblyName);
 

--- a/src/Core/ScriptRuntimes/NetPad.ExternalProcessScriptRuntime/ExternalProcessScriptRuntime.Setup.cs
+++ b/src/Core/ScriptRuntimes/NetPad.ExternalProcessScriptRuntime/ExternalProcessScriptRuntime.Setup.cs
@@ -128,7 +128,6 @@ public partial class ExternalProcessScriptRuntime
                     _script.Config.TargetFrameworkVersion,
                     referenceAssemblyImages.Select(a => a.Image).ToHashSet(),
                     referenceAssemblyPaths)
-                .WithOutputAssemblyNameTag(_script.Name)
                 .WithOptimizationLevel(_script.Config.OptimizationLevel)
                 .WithUseAspNet(_script.Config.UseAspNet);
 

--- a/src/Core/ScriptRuntimes/NetPad.InMemoryScriptRuntime/InMemoryScriptRuntime.cs
+++ b/src/Core/ScriptRuntimes/NetPad.InMemoryScriptRuntime/InMemoryScriptRuntime.cs
@@ -175,8 +175,7 @@ public sealed class InMemoryScriptRuntime : IScriptRuntime
                 fullProgram,
                 _script.Config.TargetFrameworkVersion,
                 referenceAssemblyImages.Select(a => a.Image).ToHashSet(),
-                referenceAssemblyPaths)
-            .WithOutputAssemblyNameTag(_script.Name));
+                referenceAssemblyPaths));
 
         if (!compilationResult.Success)
         {

--- a/src/Infrastructure/NetPad.Infrastructure/Data/EntityFrameworkCore/EntityFrameworkResourcesGenerator.cs
+++ b/src/Infrastructure/NetPad.Infrastructure/Data/EntityFrameworkCore/EntityFrameworkResourcesGenerator.cs
@@ -130,7 +130,6 @@ public class EntityFrameworkResourcesGenerator : IDataConnectionResourcesGenerat
                 null,
                 assemblyFileReferences)
             .WithOutputKind(OutputKind.DynamicallyLinkedLibrary)
-            .WithOutputAssemblyNameTag($"data-connection_{efConnection.Id}")
         );
     }
 


### PR DESCRIPTION
closes #157 

Script assembly name will now be `NetPadScript`. Users can reference external assembly internals by add this to their external assemblies:

```csharp
[InternalsVisibleTo("NetPadScript")]
```