### PR TITLE
Ability to control display size of media files

### DIFF
--- a/src/Apps/NetPad.Apps.App/App/src/windows/main/output-view/output-view.scss
+++ b/src/Apps/NetPad.Apps.App/App/src/windows/main/output-view/output-view.scss
@@ -115,32 +115,15 @@ output-view {
                 }
             }
 
-            &.image {
-                img {
-                    max-height: 300px;
-                }
-            }
-
-            &.video {
-                video {
-                    max-height: 300px;
-                    min-width: 350px;
-                }
-            }
-
             &.audio {
                 audio {
-                    min-width: 350px;
-                    padding: 0.5rem;
+                    width: 35%;
                 }
             }
 
             td {
                 img, audio, video {
-                    padding: 0.5rem;
-                    max-height: 300px;
-                    margin-left: 50%;
-                    transform: translateX(-50%);
+                    margin: 5px 0;
                 }
             }
 

--- a/src/Core/NetPad.Presentation/Media/MediaFile.cs
+++ b/src/Core/NetPad.Presentation/Media/MediaFile.cs
@@ -72,6 +72,19 @@ public abstract class MediaFile
         _htmlSource = Uri.ToString();
     }
 
+    /// <summary>
+    /// The width in which this media file should be displayed.
+    /// </summary>
+    public string? DisplayWidth { get; set; }
+
+    /// <summary>
+    /// The height in which this media file should be displayed.
+    /// </summary>
+    public string? DisplayHeight { get; set; }
+
+    /// <summary>
+    /// The path to the file this media file represents. Will be null if file is not local.
+    /// </summary>
     public FilePath? FilePath
     {
         get => _filePath;
@@ -82,6 +95,9 @@ public abstract class MediaFile
         }
     }
 
+    /// <summary>
+    /// The Base64 encoded data representing the contents of this media file.
+    /// </summary>
     public string? Base64Data
     {
         get => _base64Data;
@@ -92,6 +108,9 @@ public abstract class MediaFile
         }
     }
 
+    /// <summary>
+    /// The URI from where this media file is loaded.
+    /// </summary>
     public Uri? Uri
     {
         get => _uri;
@@ -101,6 +120,16 @@ public abstract class MediaFile
             UpdateHtmlSource();
         }
     }
+
+    /// <summary>
+    /// Indicates if this file points to a local file. Returns true only if <see cref="FilePath"/> is not null.
+    /// </summary>
+    public bool IsLocalFile => FilePath != null;
+
+    /// <summary>
+    /// The HTML source used to load this media file in an HTML element.
+    /// </summary>
+    public string HtmlSource => _htmlSource ?? string.Empty;
 
     private void UpdateHtmlSource()
     {
@@ -121,13 +150,6 @@ public abstract class MediaFile
             _htmlSource = null;
         }
     }
-
-    /// <summary>
-    /// Indicates if this file points to a local file. Returns true if <see cref="FilePath"/> is not null.
-    /// </summary>
-    public bool IsLocalFile => FilePath != null;
-
-    public string HtmlSource => _htmlSource ?? string.Empty;
 
     /// <summary>
     /// Opens file with the default application. Does not wait for spawned process to exit.

--- a/src/Core/NetPad.Presentation/Media/MediaFileExtensions.cs
+++ b/src/Core/NetPad.Presentation/Media/MediaFileExtensions.cs
@@ -1,0 +1,29 @@
+﻿namespace NetPad.Media;
+
+public static class MediaFileExtensions
+{
+    /// <summary>
+    /// Sets the <see cref="MediaFile.DisplayWidth"/> of this media file and returns the same instance.
+    /// </summary>
+    public static T WithDisplayWidth<T>(this T file, string width) where T : MediaFile
+    {
+        file.DisplayWidth = width;
+        return file;
+    }
+
+    /// <summary>
+    /// Sets the <see cref="MediaFile.DisplayHeight"/> of this media file and returns the same instance.
+    /// </summary>
+    public static T WithDisplayHeight<T>(this T file, string height) where T : MediaFile
+    {
+        file.DisplayHeight = height;
+        return file;
+    }
+
+    /// <summary>
+    /// Sets the <see cref="MediaFile.DisplayWidth"/> and <see cref="MediaFile.DisplayHeight"/> of this media file and returns the same instance.
+    /// </summary>
+    public static T WithDisplaySize<T>(this T file, string width, string height) where T : MediaFile =>
+        file.WithDisplayWidth<T>(width)
+            .WithDisplayHeight<T>(height);
+}

--- a/src/Core/NetPad.Presentation/Presentation/Html/AudioHtmlConverter.cs
+++ b/src/Core/NetPad.Presentation/Presentation/Html/AudioHtmlConverter.cs
@@ -19,10 +19,22 @@ public class AudioHtmlConverter : ObjectHtmlConverter
 
         string title = audio.FilePath?.Path ?? audio.Uri?.ToString() ?? (audio.Base64Data == null ? "(no source)" : "Base 64 data");
 
-        return new Element("audio")
+        var element = new Element("audio")
             .SetAttribute("controls")
             .SetSrc(audio.HtmlSource)
             .SetTitle($"Audio: {title}");
+
+        if (!string.IsNullOrWhiteSpace(audio.DisplayWidth))
+        {
+            element.GetOrAddAttribute("style").Append($"width: {audio.DisplayWidth};");
+        }
+
+        if (!string.IsNullOrWhiteSpace(audio.DisplayHeight))
+        {
+            element.GetOrAddAttribute("style").Append($"height: {audio.DisplayHeight};");
+        }
+
+        return element;
     }
 
     public override void WriteHtmlWithinTableRow<T>(Element tr, T obj, Type type, SerializationScope serializationScope, HtmlSerializer htmlSerializer)

--- a/src/Core/NetPad.Presentation/Presentation/Html/ImageHtmlConverter.cs
+++ b/src/Core/NetPad.Presentation/Presentation/Html/ImageHtmlConverter.cs
@@ -18,10 +18,22 @@ public class ImageHtmlConverter : HtmlConverter
 
         string title = image.FilePath?.Path ?? image.Uri?.ToString() ?? (image.Base64Data == null ? "(no source)" : "Base 64 data");
 
-        return new Element("<img />")
+        var element = new Element("<img />")
             .SetSrc(image.HtmlSource)
             .SetAttribute("alt", title)
             .SetTitle($"Image: {title}");
+
+        if (!string.IsNullOrWhiteSpace(image.DisplayWidth))
+        {
+            element.GetOrAddAttribute("style").Append($"width: {image.DisplayWidth};");
+        }
+
+        if (!string.IsNullOrWhiteSpace(image.DisplayHeight))
+        {
+            element.GetOrAddAttribute("style").Append($"height: {image.DisplayHeight};");
+        }
+
+        return element;
     }
 
     public override void WriteHtmlWithinTableRow<T>(Element tr, T obj, Type type, SerializationScope serializationScope, HtmlSerializer htmlSerializer)

--- a/src/Core/NetPad.Presentation/Presentation/Html/VideoHtmlConverter.cs
+++ b/src/Core/NetPad.Presentation/Presentation/Html/VideoHtmlConverter.cs
@@ -18,13 +18,23 @@ public class VideoHtmlConverter : HtmlConverter
 
         string title = video.FilePath?.Path ?? video.Uri?.ToString() ?? (video.Base64Data == null ? "(no source)" : "Base 64 data");
 
-        var videoElement = new Element("video").SetTitle($"Video: {title}");
-        videoElement.GetOrAddAttribute("controls");
+        var element = new Element("video").SetTitle($"Video: {title}");
+        element.GetOrAddAttribute("controls");
 
-        videoElement.AddAndGetElement("source")
+        element.AddAndGetElement("source")
             .SetSrc(video.HtmlSource);
 
-        return videoElement;
+        if (!string.IsNullOrWhiteSpace(video.DisplayWidth))
+        {
+            element.GetOrAddAttribute("style").Append($"width: {video.DisplayWidth};");
+        }
+
+        if (!string.IsNullOrWhiteSpace(video.DisplayHeight))
+        {
+            element.GetOrAddAttribute("style").Append($"height: {video.DisplayHeight};");
+        }
+
+        return element;
     }
 
     public override void WriteHtmlWithinTableRow<T>(Element tr, T obj, Type type, SerializationScope serializationScope, HtmlSerializer htmlSerializer)


### PR DESCRIPTION
Change default media file styling to more sane values and adds ability for user to choose display size for media files. Example:

```csharp
// Method 1: Use the new DisplayWidth  and DisplayHeight  properties
new Image("/path/image.png")
{
    DisplayWidth = "400px",
    DisplayHeight = "400px"
}.Dump()

// Method 2: Use chainable methods WithDisplayWidth(), WithDisplayHeight(), WithDisplaySize()
Image.FromPath("/path/image.png")
    .WithDisplaySize("400px", "200px") // width, height
    .Dump();
```

Values can be any valid value for CSS properties `width` and `height`:

```csharp
 Image.FromPath("/path/image.png")
    .WithDisplayWidth("75%")
    .Dump();
```