### PR TITLE
Change web port

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ cd Apps/NetPad.Apps.App
 dotnet watch run --environment Development
 ```
 
-and access the app via your web browser, ex: `http://localhost:57930`
+and access the app via your web browser, ex: `http://localhost:57940`
 
 ## Packaging :package:
 


### PR DESCRIPTION
While investigating the bug where `Console.WriteLine` did not work with chars, I noticed an inconsistency in the documentation. The instructions stated that the port should be `57930` for development, whereas `57940` is actually used for development and `57930` is for a published app.

Changes Made:
- Corrected the development port number in the documentation from 57930 to 57940.

**Notes:**
I did not find any contributing guidelines in the repository, so I hope this format is acceptable.

I love your project and hope to continue contributing!