### PR TITLE
Fix Console.WriteLine(char) Overload Not Displaying in Results Panel

### DIFF
--- a/src/Core/NetPad.Runtime/ExecutionModel/External/Interface/ActionTextWriter.cs
+++ b/src/Core/NetPad.Runtime/ExecutionModel/External/Interface/ActionTextWriter.cs
@@ -3,7 +3,7 @@ using System.Text;
 
 namespace NetPad.ExecutionModel.External.Interface;
 
-internal class ActionTextWriter(Action<string?, bool> write) : TextWriter
+internal class ActionTextWriter(Action<object?, bool> write) : TextWriter
 {
     public override Encoding Encoding => Encoding.Default;
 
@@ -19,12 +19,12 @@ internal class ActionTextWriter(Action<string?, bool> write) : TextWriter
 
     public override void Write(char value)
     {
-        write(value.ToString(), false);
+        write(value, false);
     }
 
     public override void WriteLine(char value)
     {
-        write(value.ToString(), true);
+        write(value, true);
     }
 
     public override void WriteLine()

--- a/src/Core/NetPad.Runtime/ExecutionModel/External/Interface/ActionTextWriter.cs
+++ b/src/Core/NetPad.Runtime/ExecutionModel/External/Interface/ActionTextWriter.cs
@@ -17,6 +17,16 @@ internal class ActionTextWriter(Action<string?, bool> write) : TextWriter
         write(value, true);
     }
 
+    public override void Write(char value)
+    {
+        write(value.ToString(), false);
+    }
+
+    public override void WriteLine(char value)
+    {
+        write(value.ToString(), true);
+    }
+
     public override void WriteLine()
     {
         write("\n", false);


### PR DESCRIPTION
Addresses issue #225 , where the `Console.WriteLine(char value)` overload was not displaying correctly in the Results Panel.

### Additional Notes
Did not found any unit tests for the `ActionWriter`, but could add that if we want it now?