### PR TITLE
Add signing to release binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,11 @@ jobs:
 
       - name: 🧐 Test
         run: dotnet test --no-build --verbosity normal
+
+      - name: 🔏 Sign binaries
+        if: runner.os == 'Windows'
+        run: |
+          osslsigncode sign -certs ${{ secrets.SIGN_CERT_PATH }} -key ${{ secrets.SIGN_CERT_PASS }} -in path/to/binary.exe -out path/to/signed_binary.exe
   
   spa:
     name: "SPA App"

--- a/scripts/package-electron.sh
+++ b/scripts/package-electron.sh
@@ -57,6 +57,11 @@ if ! command -v electronize &> /dev/null; then
     exit 1
 fi
 
+if ! command -v osslsigncode &> /dev/null; then
+    echo "Could not find 'osslsigncode'."
+    exit 1
+fi
+
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 APP_DIR=$(cd "$SCRIPT_DIR/../src/Apps/NetPad.Apps.App" && pwd)
 PACKAGES_SOURCE_DIR="$APP_DIR/bin/Desktop"
@@ -116,6 +121,12 @@ package() {
 
     echo "   - Copying: $filename"
     mv "$filename" "$PACKAGES_DEST_DIR/$filename"
+
+    if [[ $filename == *.exe* ]]; then
+      echo "   - Signing: $filename"
+      osslsigncode sign -certs "$SIGN_CERT_PATH" -key "$SIGN_CERT_PASS" -in "$PACKAGES_DEST_DIR/$filename" -out "$PACKAGES_DEST_DIR/$filename.signed"
+      mv "$PACKAGES_DEST_DIR/$filename.signed" "$PACKAGES_DEST_DIR/$filename"
+    fi
   done
 }
 

--- a/src/Apps/NetPad.Apps.App/electron.manifest.js
+++ b/src/Apps/NetPad.Apps.App/electron.manifest.js
@@ -81,7 +81,12 @@ const electronBuilderConfig = {
             {
                 target: "zip"
             }
-        ]
+        ],
+        sign: {
+            certificateFile: process.env.SIGN_CERT_PATH,
+            certificatePassword: process.env.SIGN_CERT_PASS,
+            signToolPath: "osslsigncode"
+        }
     },
     pacman: {
         artifactName: "${name}-${version}-${os}-${arch}.${ext}",


### PR DESCRIPTION
Fixes #132

Add code signing to release binaries

* **scripts/package-electron.sh**
  - Add a check for `osslsigncode` command.
  - Add steps to sign `.exe` files using `osslsigncode` with environment variables for certificate path and password.

* **src/Apps/NetPad.Apps.App/electron.manifest.js**
  - Add signing options for Windows binaries using `osslsigncode` with environment variables for certificate path and password.

* **.github/workflows/build.yml**
  - Add a step to sign Windows binaries using `osslsigncode` with secrets for certificate path and password.

