### PR TITLE
Fix zoom functionality

### DIFF
--- a/src/Apps/NetPad.Apps.App/App/src/core/@application/main-menu/main-menu-service.ts
+++ b/src/Apps/NetPad.Apps.App/App/src/core/@application/main-menu/main-menu-service.ts
@@ -246,8 +246,7 @@ export class MainMenuService implements IMainMenuService {
                     {
                         text: "Zoom In",
                         icon: "zoom-in-icon",
-                        helpText: "Ctrl + =",
-                        click: async () => this.windowService.zoomIn(),
+                        shortcut: this.shortcutManager.getShortcut(ShortcutIds.zoomIn),
                     },
                     {
                         text: "Zoom Out",

--- a/src/Apps/NetPad.Apps.App/App/src/core/@application/main-menu/main-menu-service.ts
+++ b/src/Apps/NetPad.Apps.App/App/src/core/@application/main-menu/main-menu-service.ts
@@ -246,16 +246,19 @@ export class MainMenuService implements IMainMenuService {
                     {
                         text: "Zoom In",
                         icon: "zoom-in-icon",
-                        helpText: "Ctrl + +",
+                        helpText: "Ctrl + =",
+                        click: async () => this.windowService.zoomIn(),
                     },
                     {
                         text: "Zoom Out",
                         icon: "zoom-out-icon",
                         helpText: "Ctrl + -",
+                        click: async () => this.windowService.zoomOut()
                     },
                     {
                         text: "Reset Zoom",
                         helpText: "Ctrl + 0",
+                        click: async () => this.windowService.resetZoom()
                     },
                     {
                         text: "Toggle Full Screen",

--- a/src/Apps/NetPad.Apps.App/App/src/core/@application/platforms/browser/services/browser-window-service.ts
+++ b/src/Apps/NetPad.Apps.App/App/src/core/@application/platforms/browser/services/browser-window-service.ts
@@ -14,6 +14,18 @@ export class BrowserWindowService extends WindowApiClient implements IWindowServ
         throw new PlatformNotSupportedError();
     }
 
+    public zoomIn(): Promise<void> {
+        throw new PlatformNotSupportedError();
+    }
+
+    public zoomOut(): Promise<void> {
+        throw new PlatformNotSupportedError();
+    }
+
+    public resetZoom(): Promise<void> {
+        throw new PlatformNotSupportedError();
+    }
+
     public toggleDeveloperTools(): Promise<void> {
         throw new PlatformNotSupportedError();
     }

--- a/src/Apps/NetPad.Apps.App/App/src/core/@application/platforms/electron/electron-ipc-event-names.ts
+++ b/src/Apps/NetPad.Apps.App/App/src/core/@application/platforms/electron/electron-ipc-event-names.ts
@@ -2,6 +2,9 @@ export class ElectronIpcEventNames {
     public static readonly getWindowState = "get-window-state";
     public static readonly maximize = "maximize";
     public static readonly minimize = "minimize";
+    public static readonly zoomIn = "zoom-in";
+    public static readonly zoomOut = "zoom-out";
+    public static readonly resetZoom = "reset-zoom";
     public static readonly toggleFullScreen = "toggle-full-screen";
     public static readonly toggleAlwaysOnTop = "toggle-always-on-top";
     public static readonly toggleDeveloperTools = "toggle-developer-tools";

--- a/src/Apps/NetPad.Apps.App/App/src/core/@application/platforms/electron/services/electron-window-service.ts
+++ b/src/Apps/NetPad.Apps.App/App/src/core/@application/platforms/electron/services/electron-window-service.ts
@@ -30,6 +30,18 @@ export class ElectronWindowService extends WindowApiClient implements IWindowSer
         return this.electronIpcGateway.send(new ChannelInfo(ElectronIpcEventNames.minimize));
     }
 
+    zoomIn(): Promise<void> {
+        return this.electronIpcGateway.send(new ChannelInfo(ElectronIpcEventNames.zoomIn));
+    }
+
+    zoomOut(): Promise<void> {
+        return this.electronIpcGateway.send(new ChannelInfo(ElectronIpcEventNames.zoomOut));
+    }
+
+    resetZoom(): Promise<void> {
+        return this.electronIpcGateway.send(new ChannelInfo(ElectronIpcEventNames.resetZoom));
+    }
+
     toggleDeveloperTools(): Promise<void> {
         return this.electronIpcGateway.send(new ChannelInfo(ElectronIpcEventNames.toggleDeveloperTools));
     }

--- a/src/Apps/NetPad.Apps.App/App/src/core/@application/shortcuts/builtin-shortcuts.ts
+++ b/src/Apps/NetPad.Apps.App/App/src/core/@application/shortcuts/builtin-shortcuts.ts
@@ -1,5 +1,5 @@
 import {KeyCode} from "@common";
-import {CreateScriptDto, IScriptService, ISettingsService} from "@application";
+import {CreateScriptDto, IScriptService, ISettingsService, IWindowService} from "@application";
 import {Shortcut} from "./shortcut";
 import {ITextEditorService} from "../editor/itext-editor-service";
 
@@ -18,6 +18,7 @@ export enum ShortcutIds {
     openExplorer = "shortcut.explorer.open",
     openNamespaces = "shortcut.namespaces.open",
     reloadWindow = "shortcut.window.reload",
+    zoomIn = "shortcut.window.zoomIn",
 }
 
 export const BuiltinShortcuts = [
@@ -169,5 +170,13 @@ export const BuiltinShortcuts = [
         .hasAction(() => window.location.reload())
         .captureDefaultKeyCombo()
         .configurable()
+        .enabled(),
+
+    new Shortcut(ShortcutIds.zoomIn, "Zoom In")
+        .withCtrlKey()
+        .withKey(KeyCode.Equal)
+        .hasAction((ctx) => ctx.container.get(IWindowService).zoomIn())
+        .captureDefaultKeyCombo()
+        .configurable(false)
         .enabled(),
 ];

--- a/src/Apps/NetPad.Apps.App/App/src/core/@application/windows/iwindow-service.ts
+++ b/src/Apps/NetPad.Apps.App/App/src/core/@application/windows/iwindow-service.ts
@@ -9,6 +9,12 @@ export interface IWindowService extends IWindowApiClient {
 
     minimize(): Promise<void>;
 
+    zoomIn(): Promise<void>;
+
+    zoomOut(): Promise<void>;
+
+    resetZoom(): Promise<void>;
+
     toggleFullScreen(): Promise<void>;
 
     toggleAlwaysOnTop(): Promise<void>;

--- a/src/Apps/NetPad.Apps.App/ElectronHostHook/app/window-controls/window-controls-manager.ts
+++ b/src/Apps/NetPad.Apps.App/ElectronHostHook/app/window-controls/window-controls-manager.ts
@@ -5,6 +5,9 @@ export class IpcEventNames {
     public static readonly getWindowState = "get-window-state";
     public static readonly maximize = "maximize";
     public static readonly minimize = "minimize";
+    public static readonly zoomIn = "zoom-in";
+    public static readonly zoomOut = "zoom-out";
+    public static readonly resetZoom = "reset-zoom";
     public static readonly toggleFullScreen = "toggle-full-screen";
     public static readonly toggleAlwaysOnTop = "toggle-always-on-top";
     public static readonly toggleDeveloperTools = "toggle-developer-tools";
@@ -30,6 +33,15 @@ export class WindowControlsManager {
             }],
             [IpcEventNames.maximize, window => window.isMaximized() ? window.unmaximize() : window.maximize()],
             [IpcEventNames.minimize, window => window.isMinimized() ? window.restore() : window.minimize()],
+            [IpcEventNames.zoomIn, window => {
+                const currentZoomFactor = window.webContents.getZoomFactor();
+                window.webContents.setZoomFactor(currentZoomFactor + 0.1);
+            }],
+            [IpcEventNames.zoomOut, window => {
+                const currentZoomFactor = window.webContents.getZoomFactor();
+                window.webContents.setZoomFactor(currentZoomFactor - 0.1);
+            }],
+            [IpcEventNames.resetZoom, window => window.webContents.setZoomFactor(1)],
             [IpcEventNames.toggleFullScreen, window => window.setFullScreen(!window.isFullScreen())],
             [IpcEventNames.toggleAlwaysOnTop, window => window.setAlwaysOnTop(!window.isAlwaysOnTop(), "normal")],
             [IpcEventNames.toggleDeveloperTools, window => window.webContents.toggleDevTools()],


### PR DESCRIPTION
Noticed that there was a zooming issue where the mappings `Ctrl + -` and `Ctrl + 0` worked, but not `Ctrl + +`. Additionally, the user could not adjust the zoom from the menu view.

This addresses the zoom adjustments in the menu view and zoom shortcuts.

**Changes made:**
* Changed the help text for **zoom-in** form `ctrl + +` to `ctrl + =` (default for Electron, plus there was no shortcut for `ctrl + +`).
* Implemented zoom functionality in `IWindowService` and the classes that extend the interface.
* Added handlers for zoom functionality in `window-controls-manager.ts`.