### PR TITLE
Add startup command for web environment in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,8 +100,11 @@ electronize start /watch /manifest electron.manifest.dev.js
 
 ```bash
 # Install dependencies
-cd src/Apps/NetPad.Apps.App/
+cd src/Apps/NetPad.Apps.App/App/
 npm install
+
+# Start the development web server
+npm run start-web
 ```
 
 2. Start the development web server


### PR DESCRIPTION
While reviewing issue #278, I noticed that the startup command for the web environment was missing from the documentation.

#### Changed made
  * Added a step to run the web environment in `CONTRIBUTING.md`