### PR TITLE
Fixes #280 bug results getting cleared when switching tabs and then back to a script that is still running in the background

### DIFF
--- a/src/Apps/NetPad.Apps.App/App/src/windows/main/panes/output-pane/components/results-view/results-view.ts
+++ b/src/Apps/NetPad.Apps.App/App/src/windows/main/panes/output-pane/components/results-view/results-view.ts
@@ -1,4 +1,3 @@
-import {watch} from "@aurelia/runtime-html";
 import {KeyCode, System, Util} from "@common";
 import {ChannelInfo, IIpcGateway, ScriptStatus} from "@application";
 import {ExcelExportDialog} from "../excel-export/excel-export-dialog";
@@ -38,15 +37,6 @@ export class ResultsView extends OutputViewBase {
 
         this.txtUserInput.addEventListener("keydown", userInputKeyHandler);
         this.addDisposable(() => this.txtUserInput.removeEventListener("keydown", userInputKeyHandler));
-    }
-
-    @watch<ResultsView>(vm => vm.model.environment.status)
-    private scriptStatusChanged(newStatus: ScriptStatus, oldStatus: ScriptStatus) {
-        this.model.inputRequest = null;
-
-        if (oldStatus !== "Running" && newStatus === "Running") {
-            this.model.resultsDumpContainer.clearOutput(true);
-        }
     }
 
     private async exportOutputToExcel() {

--- a/src/Apps/NetPad.Apps.App/App/src/windows/main/panes/output-pane/components/sql-view/sql-view.ts
+++ b/src/Apps/NetPad.Apps.App/App/src/windows/main/panes/output-pane/components/sql-view/sql-view.ts
@@ -1,13 +1,5 @@
-import {watch} from "@aurelia/runtime-html";
-import {ScriptStatus} from "@application";
 import {OutputViewBase} from "../output-view-base";
 
 export class SqlView extends OutputViewBase {
-    @watch<SqlView>(vm => vm.model.environment.status)
-    private scriptStatusChanged(newStatus: ScriptStatus, oldStatus: ScriptStatus) {
-        if (oldStatus !== "Running" && newStatus === "Running") {
-            this.model.sqlDumpContainer.clearOutput(true);
-        }
-    }
 }
 


### PR DESCRIPTION
closes #280 

When switching between tabs, new and old status were from different script environments. The comparison that existed was invalid and there was no way to know if the status change occured on the same environment or not. Moved it to OutputPane (one level up in the component hierarchy)