### PR TITLE
Use correct runtime type

### DIFF
--- a/src/External/O2Html/Converters/ObjectHtmlConverter.cs
+++ b/src/External/O2Html/Converters/ObjectHtmlConverter.cs
@@ -30,9 +30,7 @@ public class ObjectHtmlConverter : HtmlConverter
             var name = property.Name;
             object? value = GetPropertyValue(property, ref obj!);
 
-            var propertyType = value == null || property.PropertyType != typeof(object)
-                ? property.PropertyType
-                : value.GetType();
+            var propertyType = value?.GetType() ?? property.PropertyType;
 
             var tr = table.Body.AddAndGetRow();
 
@@ -58,9 +56,7 @@ public class ObjectHtmlConverter : HtmlConverter
         foreach (var property in properties)
         {
             object? value = GetPropertyValue(property, ref obj!);
-            var propertyType = value == null || property.PropertyType != typeof(object)
-                ? property.PropertyType
-                : value.GetType();
+            var propertyType = value?.GetType() ?? property.PropertyType;
 
             tr.AddAndGetElement("td")
                 .AddClass(htmlSerializer.SerializerOptions.CssClasses.PropertyValue)


### PR DESCRIPTION
When writing a property that is an abstract/inherited type, it would only dump properties from the declared type, rather than the type found at runtime.

Changes Made:
- Changed type used for property output from declared to runtime one

Minimal reproduction example:
```csharp
new PropContainer() { Broken = new Inherited() { Test2 = 1, Test = 213 } }.Dump();

class Based
{
    public int Test { get; set; }
}
class Inherited : Based
{
    public int Test2 { get; set; }
}
class PropContainer
{
    public required Based Broken { get; set; }
}
```