### PR TITLE
Add support for extension classes

### DIFF
--- a/src/Apps/NetPad.Apps.App/Startup.cs
+++ b/src/Apps/NetPad.Apps.App/Startup.cs
@@ -85,6 +85,8 @@ public class Startup
                 FileSystemDataConnectionResourcesCache>()
             .AddEntityFrameworkCoreDataConnectionDriver();
 
+        services.AddTransient<IExtensionsCodeProvider, FileSystemExtensionCodeProvider>();
+
         // Package management
         services.AddTransient<IPackageProvider, NuGetPackageProvider>();
 

--- a/src/Apps/NetPad.Apps.Common/Data/FileSystemExtensionCodeProvider.cs
+++ b/src/Apps/NetPad.Apps.Common/Data/FileSystemExtensionCodeProvider.cs
@@ -20,6 +20,9 @@ public class FileSystemExtensionCodeProvider(Settings settings, IDataConnectionR
         foreach (var file in Directory.GetFileSystemEntries(path))
         {
             var contents = await File.ReadAllTextAsync(file);
+            if (!Path.GetExtension(file).EqualsIgnoreCase(Script.STANDARD_EXTENSION))
+                continue;
+
             var script = await ScriptSerializer.DeserializeAsync(Script.GetNameFromPath(file), contents, repository, info);
 
             if (script.Id == currentScriptId)

--- a/src/Apps/NetPad.Apps.Common/Data/FileSystemExtensionCodeProvider.cs
+++ b/src/Apps/NetPad.Apps.Common/Data/FileSystemExtensionCodeProvider.cs
@@ -1,0 +1,33 @@
+using Microsoft.Extensions.Logging;
+using NetPad.Apps.Scripts;
+using NetPad.Compilation;
+using NetPad.Configuration;
+using NetPad.Data;
+using NetPad.DotNet;
+using NetPad.Scripts;
+
+namespace NetPad.Apps.Data;
+
+public class FileSystemExtensionCodeProvider(Settings settings, IDataConnectionRepository repository, IDotNetInfo info) : IExtensionsCodeProvider
+{
+    public async Task<IEnumerable<Script>> GetAll(Guid currentScriptId)
+    {
+        var path = Path.Combine(settings.ScriptsDirectoryPath, "Extensions");
+        if (!Directory.Exists(path))
+            return [];
+
+        List<Script> scripts = new();
+        foreach (var file in Directory.GetFileSystemEntries(path))
+        {
+            var contents = await File.ReadAllTextAsync(file);
+            var script = await ScriptSerializer.DeserializeAsync(Script.GetNameFromPath(file), contents, repository, info);
+
+            if (script.Id == currentScriptId)
+                continue;
+
+            scripts.Add(script);
+        }
+
+        return scripts;
+    }
+}

--- a/src/Core/NetPad.Runtime/Data/IExtensionsCodeProvider.cs
+++ b/src/Core/NetPad.Runtime/Data/IExtensionsCodeProvider.cs
@@ -1,0 +1,8 @@
+using NetPad.Scripts;
+
+namespace NetPad.Data;
+
+public interface IExtensionsCodeProvider
+{
+    Task<IEnumerable<Script>> GetAll(Guid currentScriptId);
+}

--- a/src/Core/NetPad.Runtime/ExecutionModel/ClientServer/ClientServerScriptRunner.Setup.cs
+++ b/src/Core/NetPad.Runtime/ExecutionModel/ClientServer/ClientServerScriptRunner.Setup.cs
@@ -7,6 +7,7 @@ using NetPad.Compilation;
 using NetPad.Configuration;
 using NetPad.Data;
 using NetPad.DotNet;
+using NetPad.DotNet.CodeAnalysis;
 using NetPad.DotNet.References;
 using NetPad.ExecutionModel.External;
 using NetPad.IO;
@@ -127,6 +128,11 @@ public partial class ClientServerScriptRunner
         if (cancellationToken.IsCancellationRequested)
         {
             return (dependencies, additionalCode);
+        }
+
+        foreach (var entry in await _extensionsCodeProvider.GetAll(_script.Id))
+        {
+            additionalCode.Add(new SourceCode(entry.Code, entry.Config.Namespaces));
         }
 
         // Add data connection resources

--- a/src/Core/NetPad.Runtime/ExecutionModel/ClientServer/ClientServerScriptRunner.cs
+++ b/src/Core/NetPad.Runtime/ExecutionModel/ClientServer/ClientServerScriptRunner.cs
@@ -47,6 +47,7 @@ public sealed partial class ClientServerScriptRunner : IScriptRunner
 {
     private readonly Script _script;
     private readonly IDataConnectionResourcesCache _dataConnectionResourcesCache;
+    private readonly IExtensionsCodeProvider _extensionsCodeProvider;
     private readonly IAppStatusMessagePublisher _appStatusMessagePublisher;
     private readonly IDotNetInfo _dotNetInfo;
     private readonly IEventBus _eventBus;
@@ -76,6 +77,7 @@ public sealed partial class ClientServerScriptRunner : IScriptRunner
         ICodeCompiler codeCompiler,
         IPackageProvider packageProvider,
         IDataConnectionResourcesCache dataConnectionResourcesCache,
+        IExtensionsCodeProvider extensionsCodeProvider,
         IAppStatusMessagePublisher appStatusMessagePublisher,
         IDotNetInfo dotNetInfo,
         IEventBus eventBus,
@@ -88,6 +90,7 @@ public sealed partial class ClientServerScriptRunner : IScriptRunner
         _codeCompiler = codeCompiler;
         _packageProvider = packageProvider;
         _dataConnectionResourcesCache = dataConnectionResourcesCache;
+        _extensionsCodeProvider = extensionsCodeProvider;
         _appStatusMessagePublisher = appStatusMessagePublisher;
         _dotNetInfo = dotNetInfo;
         _eventBus = eventBus;


### PR DESCRIPTION
Added support for adding extensions akin to `MyExtensions` from LinqPad.
The UI has currently no way to move files between folders, and attempting to run the extension itself will error out since it won't usually contain any code.

**Changes Made:**

- Added new interface `IExtensionsCodeProvider`
- Added implementation that looks for scripts in the Scripts directory + /Extensions
- Added script contents as `additionalCode` in the compilation