### PR TITLE
Support preprocessor symbols for framework version

### DIFF
--- a/src/Core/NetPad.Runtime/CodeAnalysis/CodeAnalysisService.cs
+++ b/src/Core/NetPad.Runtime/CodeAnalysis/CodeAnalysisService.cs
@@ -16,7 +16,7 @@ public class CodeAnalysisService : ICodeAnalysisService
             .WithLanguageVersion(targetFrameworkVersion.GetLatestSupportedCSharpLanguageVersion())
             // TODO investigate using SourceCodeKind.Script (see cs-scripts branch)
             .WithKind(SourceCodeKind.Regular)
-            .WithPreprocessorSymbols(PreprocessorSymbols.For(optimizationLevel));
+            .WithPreprocessorSymbols(PreprocessorSymbols.For(optimizationLevel, targetFrameworkVersion));
     }
 
     public SyntaxTree GetSyntaxTree(

--- a/src/Core/NetPad.Runtime/Compilation/PreprocessorSymbols.cs
+++ b/src/Core/NetPad.Runtime/Compilation/PreprocessorSymbols.cs
@@ -13,8 +13,22 @@ public static class PreprocessorSymbols
 
     public static string[] For(DotNetFrameworkVersion version)
     {
-        var ver = version.GetMajorVersion();
-        return ["NET", $"NET{ver}_0", $"NET{ver}_0_OR_GREATER"];
+        return ForInternal(version).ToArray();
+
+        IEnumerable<string> ForInternal(DotNetFrameworkVersion version)
+        {
+            var ver = version.GetMajorVersion();
+
+            yield return "NET";
+            yield return  $"NET{ver}_0";
+
+            // Add all past versions symbols
+            while (ver - 4 > 0)
+            {
+                yield return $"NET{ver}_0_OR_GREATER";
+                ver--;
+            }
+        }
     }
 
     public static string[] For(OptimizationLevel optimizationLevel, DotNetFrameworkVersion version) => For(optimizationLevel).Union(For(version)).ToArray();

--- a/src/Core/NetPad.Runtime/Compilation/PreprocessorSymbols.cs
+++ b/src/Core/NetPad.Runtime/Compilation/PreprocessorSymbols.cs
@@ -1,4 +1,5 @@
 using Microsoft.CodeAnalysis;
+using NetPad.DotNet;
 
 namespace NetPad.Compilation;
 
@@ -9,4 +10,12 @@ public static class PreprocessorSymbols
 
     public static string[] For(OptimizationLevel optimizationLevel) =>
         optimizationLevel == OptimizationLevel.Debug ? ForDebug : ForRelease;
+
+    public static string[] For(DotNetFrameworkVersion version)
+    {
+        var ver = version.GetMajorVersion();
+        return ["NET", $"NET{ver}_0", $"NET{ver}_0_OR_GREATER"];
+    }
+
+    public static string[] For(OptimizationLevel optimizationLevel, DotNetFrameworkVersion version) => For(optimizationLevel).Union(For(version)).ToArray();
 }


### PR DESCRIPTION
Adds symbols for the framework version, allowing for conditional code based on framework selected.

**Changes Made:**

- Added extra overloads for `PreprocessorSymbols.For`
- Added symbols representing .net version running in scripts