### PR TITLE
Potential fix for code scanning alert no. 26: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: "Build"
+permissions:
+  contents: read
 
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "true"


### PR DESCRIPTION
Potential fix for [https://github.com/tareqimbasher/NetPad/security/code-scanning/26](https://github.com/tareqimbasher/NetPad/security/code-scanning/26)

To fix the problem, add a `permissions` block to the workflow file `.github/workflows/build.yml`. The best way is to add it at the top level (just below the `name:` key), so it applies to all jobs in the workflow unless overridden. The minimal required permission for these jobs is `contents: read`, which allows the workflow to read repository contents but not write to them. No steps in the workflow require write access, so this is sufficient. No additional imports or definitions are needed; just a YAML edit.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
