### PR TITLE
Fix error: The filename,directory name,or volume label syntax is incorrect

### DIFF
--- a/src/Core/NetPad.Runtime/DotNet/DotNetCSharpProject.References.cs
+++ b/src/Core/NetPad.Runtime/DotNet/DotNetCSharpProject.References.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using System.Reflection;
 using System.Xml.Linq;
 using NetPad.DotNet.References;
@@ -224,7 +224,7 @@ public partial class DotNetCSharpProject
             if (PackageCacheDirectoryPath is not null)
             {
                 args.Add("--package-directory");
-                args.Add($"\"{PackageCacheDirectoryPath.Path}\"");
+                args.Add(PackageCacheDirectoryPath.Path);
             }
 
             var result = await InvokeDotNetAsync(


### PR DESCRIPTION
Changes Made:
  - In the `DotNetCSharpProject` class, fix the handling of `PackageCacheDirectoryPath` by directly adding the path to the `args` list, avoiding the use of quotes.