### PR TITLE
removed enclosing quotes for package directory arg

### DIFF
--- a/src/Core/NetPad.Runtime/DotNet/DotNetCSharpProject.References.cs
+++ b/src/Core/NetPad.Runtime/DotNet/DotNetCSharpProject.References.cs
@@ -224,7 +224,7 @@ public partial class DotNetCSharpProject
             if (PackageCacheDirectoryPath is not null)
             {
                 args.Add("--package-directory");
-                args.Add($"\"{PackageCacheDirectoryPath.Path}\"");
+                args.Add($"{PackageCacheDirectoryPath.Path}");
             }
 
             var result = await InvokeDotNetAsync(


### PR DESCRIPTION
- fix #392 

This seems to be a small bug into dotnet add. Quotes lead to fails. However unescaped paths works anyway.