### PR TITLE
[codex] Add bar graph support for numeric result columns

### DIFF
--- a/src/Apps/NetPad.Apps.App/App/src/windows/main/panes/output-pane/components/result-controls.ts
+++ b/src/Apps/NetPad.Apps.App/App/src/windows/main/panes/output-pane/components/result-controls.ts
@@ -2,6 +2,9 @@ import {WithDisposables} from "@common";
 import {ResizableTable} from "@application/tables/resizable-table";
 
 export class ResultControls extends WithDisposables {
+    private static readonly barGraphHeaderAttr = "data-bar-graph";
+    private static readonly barGraphValueAttr = "data-bar-graph-value";
+
     constructor(private readonly resultsElement: HTMLElement) {
         super();
     }
@@ -52,6 +55,8 @@ export class ResultControls extends WithDisposables {
             const resizableTable = new ResizableTable(table);
             resizableTable.init();
             this.addDisposable(resizableTable);
+
+            this.addBarGraphControls(table);
 
             if (table.tBodies.length > 0) {
                 const cells = Array.from(table.querySelectorAll(":scope > tbody > tr > td")) as HTMLTableCellElement[];
@@ -110,6 +115,152 @@ export class ResultControls extends WithDisposables {
             collapseTarget = table.querySelector(":scope > thead > tr > th");
 
         return collapseTarget;
+    }
+
+    private addBarGraphControls(table: HTMLTableElement) {
+        const headerRow = this.getTableDataHeaderRow(table);
+        if (!headerRow) {
+            return;
+        }
+
+        const headers = Array.from(headerRow.cells).filter((cell): cell is HTMLTableCellElement => cell instanceof HTMLTableCellElement);
+        for (const [columnIndex, header] of headers.entries()) {
+            if (header.getAttribute(ResultControls.barGraphHeaderAttr) !== "true") {
+                continue;
+            }
+
+            const existingButton = header.querySelector(":scope > .bar-graph-toggle");
+            const button = existingButton instanceof HTMLElement ? existingButton : document.createElement("i");
+            button.classList.add("icon-button", "bar-graph-toggle", "fa-solid", "fa-chart-simple");
+            button.setAttribute("title", "Toggle bar graph");
+            button.tabIndex = 0;
+
+            const toggle = () => {
+                const active = button.classList.toggle("active");
+                header.classList.toggle("bar-graph-active", active);
+                this.toggleBarGraphColumn(table, columnIndex, active);
+            };
+
+            const clickHandler = (e: Event) => {
+                e.stopPropagation();
+                toggle();
+            };
+
+            const keyDownHandler = (e: KeyboardEvent) => {
+                if (e.key !== "Enter" && e.key !== " ") {
+                    return;
+                }
+
+                e.preventDefault();
+                e.stopPropagation();
+                toggle();
+            };
+
+            button.addEventListener("click", clickHandler);
+            button.addEventListener("keydown", keyDownHandler);
+            this.addDisposable(() => {
+                button.removeEventListener("click", clickHandler);
+                button.removeEventListener("keydown", keyDownHandler);
+            });
+
+            if (!button.parentElement) {
+                header.appendChild(button);
+            }
+        }
+    }
+
+    private toggleBarGraphColumn(table: HTMLTableElement, columnIndex: number, show: boolean) {
+        const cells = this.getDirectBodyCells(table, columnIndex);
+        if (!cells.length) {
+            return;
+        }
+
+        if (!show) {
+            for (const cell of cells) {
+                cell.classList.remove("bar-graph-cell");
+                cell.classList.remove("bar-graph-negative");
+                cell.querySelector(":scope > .bar-graph-track")?.remove();
+            }
+
+            return;
+        }
+
+        const numericCells = cells
+            .map(cell => ({
+                cell,
+                value: Number(cell.getAttribute(ResultControls.barGraphValueAttr))
+            }))
+            .filter((entry) => !Number.isNaN(entry.value));
+
+        if (!numericCells.length) {
+            return;
+        }
+
+        const maxValue = Math.max(numericCells.reduce((max, current) => Math.max(max, Math.abs(current.value)), 0), 1);
+
+        for (const {cell, value} of numericCells) {
+            cell.classList.add("bar-graph-cell");
+            cell.classList.toggle("bar-graph-negative", value < 0);
+            this.ensureBarGraphValueWrapper(cell);
+
+            const track = cell.querySelector(":scope > .bar-graph-track") ?? document.createElement("span");
+            const fill = track.firstElementChild ?? document.createElement("span");
+
+            track.classList.add("bar-graph-track");
+            fill.classList.add("bar-graph-fill");
+            fill.setAttribute("style", `width:${(Math.abs(value) / maxValue) * 100}%`);
+
+            if (!fill.parentElement) {
+                track.appendChild(fill);
+            }
+
+            if (!track.parentElement) {
+                cell.prepend(track);
+            }
+        }
+    }
+
+    private getTableDataHeaderRow(table: HTMLTableElement): HTMLTableRowElement | null {
+        if (!table.tHead || table.tHead.rows.length === 0) {
+            return null;
+        }
+
+        for (let i = table.tHead.rows.length - 1; i >= 0; i--) {
+            const row = table.tHead.rows[i];
+            if (Array.from(row.cells).some(cell => cell.getAttribute(ResultControls.barGraphHeaderAttr) === "true")) {
+                return row;
+            }
+        }
+
+        return null;
+    }
+
+    private getDirectBodyCells(table: HTMLTableElement, columnIndex: number) {
+        if (table.tBodies.length === 0) {
+            return [] as HTMLTableCellElement[];
+        }
+
+        return Array.from(table.tBodies[0].rows)
+            .map(row => row.cells.item(columnIndex))
+            .filter((cell): cell is HTMLTableCellElement => cell instanceof HTMLTableCellElement);
+    }
+
+    private ensureBarGraphValueWrapper(cell: HTMLTableCellElement) {
+        const existing = cell.querySelector(":scope > .bar-graph-value");
+        if (existing) {
+            return existing;
+        }
+
+        const wrapper = document.createElement("span");
+        wrapper.classList.add("bar-graph-value");
+
+        const nodes = Array.from(cell.childNodes).filter(node => !(node instanceof HTMLElement && node.classList.contains("bar-graph-track")));
+        for (const node of nodes) {
+            wrapper.appendChild(node);
+        }
+
+        cell.appendChild(wrapper);
+        return wrapper;
     }
 
     public expandAll(level?: number) {

--- a/src/Apps/NetPad.Apps.App/App/src/windows/main/panes/output-pane/output-pane.scss
+++ b/src/Apps/NetPad.Apps.App/App/src/windows/main/panes/output-pane/output-pane.scss
@@ -172,6 +172,16 @@ output-pane {
 
             thead th {
                 white-space: nowrap;
+
+                &.bar-graph-active {
+                    color: var(--active-color);
+                }
+            }
+
+            .bar-graph-toggle {
+                margin-left: 0.35rem;
+                padding: 0.15rem 0.25rem;
+                font-size: 0.8rem;
             }
 
             .table-info-header > th {
@@ -195,6 +205,40 @@ output-pane {
 
             tbody td {
                 overflow-wrap: break-word;
+            }
+
+            .bar-graph-cell {
+                position: relative;
+                overflow: hidden;
+                min-width: 5rem;
+
+                .bar-graph-track {
+                    position: absolute;
+                    left: 0.2rem;
+                    right: 0.2rem;
+                    top: 50%;
+                    height: 0.9rem;
+                    transform: translateY(-50%);
+                    border-radius: 999px;
+                    background: rgb(61 163 218 / 12%);
+                    pointer-events: none;
+                }
+
+                .bar-graph-fill {
+                    display: block;
+                    height: 100%;
+                    border-radius: inherit;
+                    background: linear-gradient(90deg, rgb(61 163 218 / 40%), rgb(61 163 218 / 85%));
+                }
+
+                .bar-graph-value {
+                    position: relative;
+                    z-index: 1;
+                }
+
+                &.bar-graph-negative .bar-graph-fill {
+                    background: linear-gradient(90deg, rgb(255 159 64 / 35%), rgb(255 159 64 / 80%));
+                }
             }
 
             tbody {

--- a/src/Apps/NetPad.Apps.App/App/test/windows/main/panes/output-pane/components/result-controls.spec.ts
+++ b/src/Apps/NetPad.Apps.App/App/test/windows/main/panes/output-pane/components/result-controls.spec.ts
@@ -1,0 +1,66 @@
+import {ResultControls} from "../../../../../../src/windows/main/panes/output-pane/components/result-controls";
+
+describe("ResultControls", () => {
+    test("adds a bar graph toggle for numeric columns", () => {
+        const {content, table} = createFragment();
+
+        const controls = new ResultControls(document.createElement("div"));
+        controls.bind(content);
+
+        const header = table.tHead?.rows[1].cells[1];
+        expect(header?.querySelector(".bar-graph-toggle")).not.toBeNull();
+        controls.dispose();
+    });
+
+    test("toggles bar graphs for numeric cells", () => {
+        const {content, table} = createFragment();
+
+        const controls = new ResultControls(document.createElement("div"));
+        controls.bind(content);
+
+        const button = table.tHead?.rows[1].cells[1].querySelector(".bar-graph-toggle") as HTMLElement;
+        button.click();
+
+        const numericCells = Array.from(table.tBodies[0].rows).map(row => row.cells[1]);
+        expect(numericCells.every(cell => cell.classList.contains("bar-graph-cell"))).toBe(true);
+        expect(numericCells[0].querySelector(".bar-graph-fill")).not.toBeNull();
+
+        button.click();
+
+        expect(numericCells.every(cell => !cell.classList.contains("bar-graph-cell"))).toBe(true);
+        expect(numericCells[0].querySelector(".bar-graph-fill")).toBeNull();
+        controls.dispose();
+    });
+});
+
+function createFragment() {
+    const template = document.createElement("template");
+    template.innerHTML = `
+        <table>
+            <thead>
+                <tr class="table-info-header">
+                    <th colspan="2">Sample (2 items)</th>
+                </tr>
+                <tr class="table-data-header">
+                    <th>Name</th>
+                    <th data-bar-graph="true" title="System.Int32">Age</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>Alice</td>
+                    <td data-bar-graph-value="10">10</td>
+                </tr>
+                <tr>
+                    <td>Bob</td>
+                    <td data-bar-graph-value="20">20</td>
+                </tr>
+            </tbody>
+        </table>
+    `;
+
+    return {
+        content: template.content,
+        table: template.content.querySelector("table") as HTMLTableElement
+    };
+}

--- a/src/External/O2Html/Converters/CollectionHtmlConverter.cs
+++ b/src/External/O2Html/Converters/CollectionHtmlConverter.cs
@@ -82,9 +82,14 @@ public class CollectionHtmlConverter : HtmlConverter
             {
                 foreach (var property in properties)
                 {
-                    table.Head
+                    var heading = table.Head
                         .AddAndGetHeading(property.Name, property.PropertyType.GetReadableName(true))
                         .AddClass(htmlSerializer.SerializerOptions.CssClasses.PropertyName);
+
+                    if (HtmlSerializer.IsNumericType(property.PropertyType))
+                    {
+                        heading.SetAttribute("data-bar-graph", "true");
+                    }
                 }
 
                 table.Head.ChildElements.Single().AddClass(htmlSerializer.SerializerOptions.CssClasses.TableDataHeader);

--- a/src/External/O2Html/Converters/DataTableHtmlConverter.cs
+++ b/src/External/O2Html/Converters/DataTableHtmlConverter.cs
@@ -21,7 +21,11 @@ public class DataTableHtmlConverter : HtmlConverter
         var table = new Table();
         foreach (DataColumn column in dataTable.Columns)
         {
-            table.Head.AddHeading(column.ColumnName, column.DataType.GetReadableName(true));
+            var heading = table.Head.AddAndGetHeading(column.ColumnName, column.DataType.GetReadableName(true));
+            if (HtmlSerializer.IsNumericType(column.DataType))
+            {
+                heading.SetAttribute("data-bar-graph", "true");
+            }
         }
 
         var enumerationResult = Enumerate.Max<DataRow>(dataTable.Rows, htmlSerializer.SerializerOptions.MaxCollectionSerializeLength, (row, _) =>
@@ -35,6 +39,11 @@ public class DataTableHtmlConverter : HtmlConverter
                 var td = tr.AddAndGetElement("td");
 
                 var itemType = item?.GetType() ?? dataTable.Columns[ixItem].DataType;
+
+                if (HtmlSerializer.TryGetNumericValueString(item is DBNull ? null : item, itemType, out var numericValue))
+                {
+                    td.SetAttribute("data-bar-graph-value", numericValue!);
+                }
 
                 if (item == null || itemType == typeof(DBNull))
                 {

--- a/src/External/O2Html/Converters/ObjectHtmlConverter.cs
+++ b/src/External/O2Html/Converters/ObjectHtmlConverter.cs
@@ -41,9 +41,15 @@ public class ObjectHtmlConverter : HtmlConverter
                 .AddText(name);
 
             // Add property value
-            tr.AddAndGetElement("td")
-                .AddClass(htmlSerializer.SerializerOptions.CssClasses.PropertyValue)
-                .AddChild(htmlSerializer.Serialize(value, propertyType, serializationScope));
+            var td = tr.AddAndGetElement("td")
+                .AddClass(htmlSerializer.SerializerOptions.CssClasses.PropertyValue);
+
+            if (HtmlSerializer.TryGetNumericValueString(value, propertyType, out var numericValue))
+            {
+                td.SetAttribute("data-bar-graph-value", numericValue!);
+            }
+
+            td.AddChild(htmlSerializer.Serialize(value, propertyType, serializationScope));
         }
 
         return table;
@@ -58,9 +64,15 @@ public class ObjectHtmlConverter : HtmlConverter
             object? value = GetPropertyValue(property, ref obj!);
             var propertyType = value?.GetType() ?? property.PropertyType;
 
-            tr.AddAndGetElement("td")
-                .AddClass(htmlSerializer.SerializerOptions.CssClasses.PropertyValue)
-                .AddChild(htmlSerializer.Serialize(value, propertyType, serializationScope));
+            var td = tr.AddAndGetElement("td")
+                .AddClass(htmlSerializer.SerializerOptions.CssClasses.PropertyValue);
+
+            if (HtmlSerializer.TryGetNumericValueString(value, propertyType, out var numericValue))
+            {
+                td.SetAttribute("data-bar-graph-value", numericValue!);
+            }
+
+            td.AddChild(htmlSerializer.Serialize(value, propertyType, serializationScope));
         }
     }
 

--- a/src/External/O2Html/HtmlSerializer.cs
+++ b/src/External/O2Html/HtmlSerializer.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
+using System.Numerics;
 using System.Reflection;
 using System.Xml;
 using System.Xml.Linq;
@@ -268,6 +270,50 @@ public sealed class HtmlSerializer
                || typeof(XNode).IsAssignableFrom(type)
                || typeof(XmlNode).IsAssignableFrom(type)
             ;
+    }
+
+    internal static bool IsNumericType(Type type)
+    {
+        type = Nullable.GetUnderlyingType(type) ?? type;
+
+        if (type == typeof(BigInteger))
+        {
+            return true;
+        }
+
+        return Type.GetTypeCode(type) switch
+        {
+            TypeCode.Byte => true,
+            TypeCode.SByte => true,
+            TypeCode.Int16 => true,
+            TypeCode.UInt16 => true,
+            TypeCode.Int32 => true,
+            TypeCode.UInt32 => true,
+            TypeCode.Int64 => true,
+            TypeCode.UInt64 => true,
+            TypeCode.Single => true,
+            TypeCode.Double => true,
+            TypeCode.Decimal => true,
+            _ => false
+        };
+    }
+
+    internal static bool TryGetNumericValueString(object? value, Type type, out string? numericValue)
+    {
+        numericValue = null;
+
+        if (value == null || !IsNumericType(type))
+        {
+            return false;
+        }
+
+        numericValue = value switch
+        {
+            IFormattable formattable => formattable.ToString(null, CultureInfo.InvariantCulture),
+            _ => Convert.ToString(value, CultureInfo.InvariantCulture)
+        };
+
+        return !string.IsNullOrWhiteSpace(numericValue);
     }
 
     public static bool IsObjectType(Type type)

--- a/src/Tests/NetPad.Runtime.Tests/Html/HtmlPresenterTests.cs
+++ b/src/Tests/NetPad.Runtime.Tests/Html/HtmlPresenterTests.cs
@@ -1,5 +1,6 @@
 using NetPad.Presentation;
 using NetPad.Presentation.Html;
+using O2Html.Dom;
 
 namespace NetPad.Runtime.Tests.Html;
 
@@ -98,5 +99,62 @@ public class HtmlPresenterTests
         var element = HtmlPresenter.SerializeToElement(output, new DumpOptions(Title: "some title", AppendNewLineToAllTextOutput: true));
 
         Assert.Equal("br", element.ChildElements.Last().TagName, StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void NumericColumns_AreMarkedForBarGraphs()
+    {
+        var output = new[]
+        {
+            new { Name = "John", Age = 30, Score = 98.5m },
+            new { Name = "Jane", Age = 25, Score = 72.25m }
+        };
+
+        var element = HtmlPresenter.SerializeToElement(output);
+
+        var headings = FindDescendants(element, "th")
+            .Where(x => x.Parent?.Parent is Element { TagName: "thead" })
+            .ToArray();
+
+        Assert.Equal("true", headings.Single(x => x.Children.OfType<TextNode>().Any(t => t.Text == "Age"))
+            .GetAttribute("data-bar-graph")?.Value);
+        Assert.Equal("true", headings.Single(x => x.Children.OfType<TextNode>().Any(t => t.Text == "Score"))
+            .GetAttribute("data-bar-graph")?.Value);
+        Assert.Null(headings.Single(x => x.Children.OfType<TextNode>().Any(t => t.Text == "Name"))
+            .GetAttribute("data-bar-graph"));
+    }
+
+    [Fact]
+    public void NumericCells_IncludeInvariantBarGraphValues()
+    {
+        var output = new[]
+        {
+            new { Name = "John", Age = 30, Score = 98.5m }
+        };
+
+        var element = HtmlPresenter.SerializeToElement(output);
+
+        var cells = FindDescendants(element, "td").ToArray();
+
+        Assert.Equal("30", cells.Single(x => x.GetAttribute("data-bar-graph-value")?.Value == "30")
+            .GetAttribute("data-bar-graph-value")?.Value);
+        Assert.Equal("98.5", cells.Single(x => x.GetAttribute("data-bar-graph-value")?.Value == "98.5")
+            .GetAttribute("data-bar-graph-value")?.Value);
+    }
+
+    private static IEnumerable<Element> FindDescendants(Element root, string tagName)
+    {
+        foreach (var child in root.ChildElements)
+        {
+            if (string.Equals(child.TagName, tagName, StringComparison.OrdinalIgnoreCase))
+            {
+                yield return child;
+            }
+
+            foreach (var descendant in FindDescendants(child, tagName))
+            {
+                yield return descendant;
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add numeric-column detection metadata to HTML table output
- add a result-pane toggle that renders simple proportional bar graphs for numeric cells
- add runtime and frontend coverage for the new toggle behavior

## Why
NetPad should offer the same quick visual scan for numeric result columns that LinqPad does, without requiring users to write charting code.

## Impact
Users can toggle lightweight inline bars for numeric columns directly in query results.

## Validation
- `dotnet test src/Tests/NetPad.Runtime.Tests/NetPad.Runtime.Tests.csproj --filter HtmlPresenterTests`
- `npm test -- --runInBand test/windows/main/panes/output-pane/components/result-controls.spec.ts`
- `npm run lint`
  - completed with existing stylelint warnings in `src/styles/_structural.scss`
