### PR TITLE
[codex] Upgrade app host to .NET 10

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           dotnet-version: |
             6.0.x
-            9.0.x
+            10.0.x
 
       - name: 🚩 Extract version from tag
         id: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,10 +152,10 @@ jobs:
         with:
           node-version: 22.x
 
-      - name: 🧲 Setup .NET 9
+      - name: 🧲 Setup .NET 10
         uses: actions/setup-dotnet@v4.0.0
         with:
-          dotnet-version: 9.0.x
+          dotnet-version: 10.0.x
 
       - name: 🧲 Install dependencies (ubuntu only)
         if: startsWith(matrix.platform, 'ubuntu-')
@@ -308,10 +308,10 @@ jobs:
         with:
           node-version: 22.x
 
-      - name: 🧲 Setup .NET 9
+      - name: 🧲 Setup .NET 10
         uses: actions/setup-dotnet@v4.0.0
         with:
-          dotnet-version: 9.0.x
+          dotnet-version: 10.0.x
 
       - name: 🧲 Setup Rust stable
         uses: dtolnay/rust-toolchain@stable

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ the [technical documentation](docs/technical-docs/).
 ### Prerequisites
 
 - [Node](https://nodejs.org/en/download) v22+
-- [.NET SDK](https://dotnet.microsoft.com/en-us/download/dotnet/9.0) 9.x
+- [.NET SDK](https://dotnet.microsoft.com/en-us/download/dotnet/10.0) 10.x
 - [EF Core tools](https://learn.microsoft.com/en-us/ef/core/cli/dotnet)
 - (Recommended) [just](https://github.com/casey/just) command runner — a `justfile` is provided with
   recipes for building, running, testing, and linting. Run `just` to see all available tasks. If you

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <DefaultTargetFramework>net9.0</DefaultTargetFramework>
+        <DefaultTargetFramework>net10.0</DefaultTargetFramework>
         <EarliestSupportedTargetFramework>net6.0</EarliestSupportedTargetFramework>
         <LangVersion>latest</LangVersion>
         <Deterministic>True</Deterministic>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 ﻿{
     "sdk": {
-        "version": "9.0.0",
+        "version": "10.0.100",
         "rollForward": "latestFeature",
         "allowPrerelease": false
     }


### PR DESCRIPTION
## Summary
- move the shared default target framework to .NET 10
- update the pinned SDK version and contributor docs accordingly
- switch CI workflows that install .NET to 10.x

## Why
The app host and its supporting workflow should build and test on the current .NET 10 toolchain instead of the previous .NET 9 baseline.

## Impact
Local development and CI for the main app/test path move to .NET 10.

## Validation
- `dotnet test src/Tests/NetPad.Runtime.Tests/NetPad.Runtime.Tests.csproj --filter DotNetFrameworkVersionUtilTests`
- `dotnet build src/Apps/NetPad.Apps.App/NetPad.Apps.App.csproj`
  - completed with existing package vulnerability, RID, and older-target warnings in untouched projects
