### PR TITLE
Handle Expression script kind and isolate script open failures

### DIFF
--- a/src/Apps/NetPad.Apps.App/App/src/windows/main/work-area/viewers/script-viewer/viewable-script-document.ts
+++ b/src/Apps/NetPad.Apps.App/App/src/windows/main/work-area/viewers/script-viewer/viewable-script-document.ts
@@ -64,9 +64,10 @@ export class ViewableScriptDocument extends ViewableTextDocument {
                 }
 
                 if (ev.propertyName === "Kind") {
-                    if (ev.newValue == "Program") this.textDocument.changeLanguage("csharp");
-                    else if (ev.newValue == "SQL") this.textDocument.changeLanguage("sql");
-                    this.iconImageSrc = LangLogoValueConverter.resolveIconImageSrc(ev.newValue as ScriptKind);
+                    const kind = ev.newValue as ScriptKind;
+                    const language = ViewableScriptDocument.tryGetLanguageFromScriptKind(kind);
+                    if (language) this.textDocument.changeLanguage(language);
+                    this.iconImageSrc = LangLogoValueConverter.resolveIconImageSrc(kind);
                 }
             })
         );
@@ -101,10 +102,21 @@ export class ViewableScriptDocument extends ViewableTextDocument {
         );
     }
 
-    private static getLanguageFromScriptKind(kind: ScriptKind): TextLanguage {
-        if (kind == "Program") return "csharp";
+    /**
+     * Maps a script kind to the language it is edited in, or undefined if the kind has no known
+     * mapping.
+     */
+    public static tryGetLanguageFromScriptKind(kind: ScriptKind): TextLanguage | undefined {
+        // "Expression" scripts are C# too. The script runtime already runs them as "Program".
+        if (kind === "Program" || kind === "Expression") return "csharp";
         else if (kind === "SQL") return "sql";
-        else throw new Error("Unhandled script kind: " + kind);
+        else return undefined;
+    }
+
+    private static getLanguageFromScriptKind(kind: ScriptKind): TextLanguage {
+        const language = ViewableScriptDocument.tryGetLanguageFromScriptKind(kind);
+        if (!language) throw new Error("Unhandled script kind: " + kind);
+        return language;
     }
 
     public override get name() {

--- a/src/Apps/NetPad.Apps.App/App/src/windows/main/work-area/work-area-service.ts
+++ b/src/Apps/NetPad.Apps.App/App/src/windows/main/work-area/work-area-service.ts
@@ -1,4 +1,4 @@
-import {DI, IContainer} from "aurelia";
+import {DI, IContainer, ILogger} from "aurelia";
 import {WithDisposables} from "@common";
 import {CreateScriptDto, EnvironmentsRemovedEvent, ScriptEnvironment} from "@application/api";
 import {IAppService} from "@application/app/iapp-service";
@@ -38,6 +38,13 @@ export interface IWorkAreaService {
      * viewable types are added, extract a separate IViewableFactory.
      */
     createScriptViewable(environment: ScriptEnvironment): ViewableScriptDocument;
+
+    /**
+     * Creates a viewable for the environment and opens it, returning whether that succeeded.
+     * Failures are logged instead of thrown so that a single script which cannot be opened does
+     * not prevent the rest of the work area from being set up.
+     */
+    openScriptViewable(environment: ScriptEnvironment): Promise<boolean>;
 }
 
 export class WorkAreaService extends WithDisposables implements IWorkAreaService {
@@ -51,6 +58,7 @@ export class WorkAreaService extends WithDisposables implements IWorkAreaService
         @ISession private readonly session: ISession,
         @IAppService private readonly appService: IAppService,
         @IEventBus private readonly eventBus: IEventBus,
+        @ILogger private readonly logger: ILogger,
     ) {
         super();
         this.appearance.load();
@@ -121,5 +129,19 @@ export class WorkAreaService extends WithDisposables implements IWorkAreaService
             this,
             this.eventBus,
         );
+    }
+
+    public async openScriptViewable(environment: ScriptEnvironment): Promise<boolean> {
+        try {
+            const viewable = this.createScriptViewable(environment);
+            await this.open(viewable);
+            return true;
+        } catch (ex) {
+            this.logger.error(
+                `Could not open script '${environment.script.name}' (${environment.script.id}) in the work area.`,
+                ex,
+            );
+            return false;
+        }
     }
 }

--- a/src/Apps/NetPad.Apps.App/App/src/windows/main/work-area/work-area.ts
+++ b/src/Apps/NetPad.Apps.App/App/src/windows/main/work-area/work-area.ts
@@ -20,10 +20,10 @@ export class WorkArea extends ViewModelBase {
 
         const service = this.workbench.workAreaService;
 
-        // Create and open a viewable for each existing script environment.
+        // Create and open a viewable for each existing script environment. A script that cannot be
+        // opened must not prevent the rest of the work area from being set up.
         for (const env of this.session.environments) {
-            const viewable = service.createScriptViewable(env);
-            await service.open(viewable);
+            await service.openScriptViewable(env);
         }
 
         // Activate the first viewer host if none is active.
@@ -56,8 +56,7 @@ export class WorkArea extends ViewModelBase {
             if (service.viewerHosts.items.some(vh => vh.find(environment.script.id)))
                 continue;
 
-            const viewable = service.createScriptViewable(environment);
-            await service.open(viewable);
+            await service.openScriptViewable(environment);
         }
 
         // Removals: remove viewables whose environment is gone.

--- a/src/Apps/NetPad.Apps.App/App/test/windows/main/work-area/viewers/script-viewer/viewable-script-document.spec.ts
+++ b/src/Apps/NetPad.Apps.App/App/test/windows/main/work-area/viewers/script-viewer/viewable-script-document.spec.ts
@@ -1,0 +1,26 @@
+import {ScriptKind} from "../../../../../../src/core/@application/api";
+import {
+    ViewableScriptDocument,
+} from "../../../../../../src/windows/main/work-area/viewers/script-viewer/viewable-script-document";
+
+describe("ViewableScriptDocument.tryGetLanguageFromScriptKind", () => {
+    test("maps Program to csharp", () => {
+        expect(ViewableScriptDocument.tryGetLanguageFromScriptKind("Program")).toBe("csharp");
+    });
+
+    test("maps Expression to csharp", () => {
+        // "Expression" is the default value of the ScriptKind enum, so any script config without an
+        // explicit kind deserializes into it. It must not be left unmapped.
+        expect(ViewableScriptDocument.tryGetLanguageFromScriptKind("Expression")).toBe("csharp");
+    });
+
+    test("maps SQL to sql", () => {
+        expect(ViewableScriptDocument.tryGetLanguageFromScriptKind("SQL")).toBe("sql");
+    });
+
+    test("returns undefined for an unknown kind", () => {
+        expect(
+            ViewableScriptDocument.tryGetLanguageFromScriptKind("NotAKind" as ScriptKind),
+        ).toBeUndefined();
+    });
+});

--- a/src/Apps/NetPad.Apps.App/App/test/windows/main/work-area/work-area-service.spec.ts
+++ b/src/Apps/NetPad.Apps.App/App/test/windows/main/work-area/work-area-service.spec.ts
@@ -14,6 +14,9 @@ import {
 } from "../../../../src/windows/main/work-area/viewers/viewer-registry";
 import {WorkAreaService} from "../../../../src/windows/main/work-area/work-area-service";
 import {
+    ViewableScriptDocument,
+} from "../../../../src/windows/main/work-area/viewers/script-viewer/viewable-script-document";
+import {
     IWorkAreaAppearance,
 } from "../../../../src/windows/main/work-area/work-area-appearance";
 
@@ -77,18 +80,31 @@ class FakeAppearance {
     public dispose(): void { /* noop */ }
 }
 
+class FakeLogger {
+    public errors: unknown[][] = [];
+    public scopeTo() { return this; }
+    public trace() { /* noop */ }
+    public debug() { /* noop */ }
+    public info() { /* noop */ }
+    public warn() { /* noop */ }
+    public fatal() { /* noop */ }
+    public error(...args: unknown[]) { this.errors.push(args); }
+}
+
 function setup(opts: {initialEnvironments?: ScriptEnvironment[]} = {}): {
     container: IContainer,
     service: WorkAreaService,
     session: FakeSession,
     scriptService: FakeScriptService,
     eventBus: FakeEventBus,
+    logger: FakeLogger,
 } {
     const container = DI.createContainer();
     const session = new FakeSession();
     session.environments = opts.initialEnvironments ?? [];
     const scriptService = new FakeScriptService();
     const eventBus = new FakeEventBus();
+    const logger = new FakeLogger();
 
     container.register(
         Registration.singleton(IViewerRegistry, ViewerRegistry),
@@ -97,12 +113,13 @@ function setup(opts: {initialEnvironments?: ScriptEnvironment[]} = {}): {
         Registration.instance(ISession, session as unknown as ISession),
         Registration.instance(IAppService, {} as IAppService),
         Registration.instance(IEventBus, eventBus as unknown as IEventBus),
+        Registration.instance(ILogger, logger as unknown as ILogger),
     );
 
     const registry = container.get(IViewerRegistry);
     registry.register({id: "test", viewerClass: TestViewer, canHandle: v => v instanceof TestViewable});
 
-    return {container, service: container.invoke(WorkAreaService), session, scriptService, eventBus};
+    return {container, service: container.invoke(WorkAreaService), session, scriptService, eventBus, logger};
 }
 
 describe("WorkAreaService.open", () => {
@@ -200,6 +217,48 @@ describe("WorkAreaService RunScriptCommand routing", () => {
         eventBus.fire(RunScriptCommand, new RunScriptCommand("v1"));
         await Promise.resolve();
         expect(runSpy).not.toHaveBeenCalled();
+    });
+});
+
+describe("WorkAreaService.openScriptViewable", () => {
+    const environment = (id: string, name: string) =>
+        ({script: {id, name}}) as unknown as ScriptEnvironment;
+
+    it("opens the viewable and reports success", async () => {
+        const {service} = setup();
+        await service.initialize();
+        const viewable = new TestViewable("s1");
+        service.createScriptViewable = () => viewable as unknown as ViewableScriptDocument;
+
+        const opened = await service.openScriptViewable(environment("s1", "Good"));
+
+        expect(opened).toBe(true);
+        expect(service.viewerHosts.items.some(h => h.viewables.has(viewable))).toBe(true);
+    });
+
+    it("reports failure instead of throwing when the viewable cannot be created", async () => {
+        // A script whose kind has no editor-language mapping throws here. It must not be allowed to
+        // propagate, otherwise the caller abandons setting up the rest of the work area.
+        const {service} = setup();
+        await service.initialize();
+        service.createScriptViewable = () => {
+            throw new Error("Unhandled script kind: Expression");
+        };
+
+        await expect(service.openScriptViewable(environment("s1", "Bad"))).resolves.toBe(false);
+    });
+
+    it("logs the script that could not be opened", async () => {
+        const {service, logger} = setup();
+        await service.initialize();
+        service.createScriptViewable = () => {
+            throw new Error("Unhandled script kind: Expression");
+        };
+
+        await service.openScriptViewable(environment("s1", "Bad"));
+
+        expect(logger.errors).toHaveLength(1);
+        expect(String(logger.errors[0][0])).toContain("s1");
     });
 });
 


### PR DESCRIPTION
Fixes the blank work area reported in #433, where a single script with `kind: "Expression"` left the
UI with no explorer, output or namespaces panes and no error shown to the user.

`getLanguageFromScriptKind` had no case for `Expression` and threw. Because
`WorkArea.attaching` creates a viewable per open script in a loop, that throw propagated out of
`attaching` and the whole work area was abandoned. `Expression` is the default value of the
`ScriptKind` enum, so any script config without an explicit kind lands on this path — it isn't
limited to imported LINQPad queries.

**Changes Made:**

- Map `Expression` to `csharp` in `ViewableScriptDocument`, matching `LangLogoValueConverter`, which
  already treats `Expression` as C#. Split the mapping into `tryGetLanguageFromScriptKind`
  (returns `undefined` for unknown kinds) with `getLanguageFromScriptKind` still throwing, so a
  genuinely unmapped kind is not silently ignored.
- Reuse that mapping in the `ScriptConfigPropertyChangedEvent` handler, which had its own
  `Program`/`SQL`-only conditional and silently skipped the language change for `Expression`.
- Add `WorkAreaService.openScriptViewable`, which creates and opens a viewable and returns whether
  it succeeded, logging failures rather than throwing. `WorkArea.attaching` and
  `WorkArea.environmentsChanged` both use it, so one script that cannot be opened no longer
  prevents the rest of the work area from being set up.
- Tests: four cases covering the kind mapping, and three covering `openScriptViewable` (success,
  failure reported rather than thrown, and the failure being logged).

The resilience change lives in `WorkAreaService` rather than `WorkArea` because `work-area.ts` has a
paired `work-area.html`, and `@aurelia/ts-jest` fails to transform a view model with a template
(`Could not find source file: work-area.html.ts`), so it cannot currently be imported from a spec.
`WorkAreaService` has no template and already has a spec, so the behaviour is directly testable
there. Adding `@ILogger` to its constructor is the only signature change; it is resolved through DI
and has no other call sites.

Verified with `npx jest` (29 suites, 436 tests, all passing), `npx eslint` on the changed files, and
`npx tsc --noEmit`, all clean.

Note that the packaging issue in #432 is unrelated and not addressed here.
