### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Thank you for your support! :heart:
 
 <br/>
 <br/>
-<img src="https://api.star-history.com/svg?repos=tareqimbasher/NetPad&type=Date" />
+<img src="https://star-history.dera.page/svg?repos=tareqimbasher/NetPad&type=Date" />
 <br/>
 <br/>
 


### PR DESCRIPTION
The star history chart in the README is currently broken because the underlying GitHub stargazer data source is no longer available. This fixes the chart by pointing it at a reliable replacement source so the project's star history renders correctly again.